### PR TITLE
Add At/Index class (#43)

### DIFF
--- a/src/At/Set.ts
+++ b/src/At/Set.ts
@@ -1,0 +1,10 @@
+import { At, Lens } from '../index'
+import { Setoid } from 'fp-ts/lib/Setoid'
+import * as S from 'fp-ts/lib/Set'
+
+export function atSet<A = never>(setoid: Setoid<A>): At<Set<A>, A, boolean> {
+  const member = S.member(setoid)
+  const insert = S.insert(setoid)
+  const remove = S.remove(setoid)
+  return new At(at => new Lens(s => member(s)(at), a => s => (a ? insert(at, s) : remove(at, s))))
+}

--- a/src/At/StrMap.ts
+++ b/src/At/StrMap.ts
@@ -1,0 +1,7 @@
+import { At, Lens } from '../index'
+import { Option } from 'fp-ts/lib/Option'
+import * as SM from 'fp-ts/lib/StrMap'
+
+export function atStrMap<A = never>(): At<SM.StrMap<A>, string, Option<A>> {
+  return new At(at => new Lens(s => SM.lookup(at, s), a => s => a.fold(SM.remove(at, s), x => SM.insert(at, x, s))))
+}

--- a/src/Index/Array.ts
+++ b/src/Index/Array.ts
@@ -1,0 +1,6 @@
+import { Index, Optional } from '../index'
+import { index, updateAt } from 'fp-ts/lib/Array'
+
+export function indexArray<A = never>(): Index<Array<A>, number, A> {
+  return new Index(i => new Optional(s => index(i, s), a => s => updateAt(i, a, s).getOrElse(s)))
+}

--- a/src/Index/StrMap.ts
+++ b/src/Index/StrMap.ts
@@ -1,0 +1,6 @@
+import { Index } from '../index'
+import { atStrMap } from '../At/StrMap'
+
+export function indexStrMap<A = never>() {
+  return Index.fromAt(atStrMap<A>())
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -577,6 +577,19 @@ export class At<S, I, A> {
   }
 }
 
+export class Index<S, I, A> {
+  readonly _tag: 'Index' = 'Index'
+  constructor(readonly index: (i: I) => Optional<S, A>) {}
+
+  static fromAt<T, J, B>(at: At<T, J, Option<B>>): Index<T, J, B> {
+    return new Index(i => at.at(i).composePrism(Prism.some()))
+  }
+
+  fromIso<T>(iso: Iso<T, S>): Index<T, I, A> {
+    return new Index(i => iso.composeOptional(this.index(i)))
+  }
+}
+
 export class Getter<S, A> {
   readonly _tag: 'Getter' = 'Getter'
   constructor(readonly get: (s: S) => A) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -568,6 +568,15 @@ export class Traversal<S, A> {
   }
 }
 
+export class At<S, I, A> {
+  readonly _tag: 'At' = 'At'
+  constructor(readonly at: (i: I) => Lens<S, A>) {}
+
+  fromIso<T>(iso: Iso<T, S>): At<T, I, A> {
+    return new At(i => iso.composeLens(this.at(i)))
+  }
+}
+
 export class Getter<S, A> {
   readonly _tag: 'Getter' = 'Getter'
   constructor(readonly get: (s: S) => A) {}

--- a/test/At.ts
+++ b/test/At.ts
@@ -1,0 +1,51 @@
+import { atSet } from '../src/At/Set'
+import { atStrMap } from '../src/At/StrMap'
+import * as assert from 'assert'
+import { none, some } from 'fp-ts/lib/Option'
+import { setoidNumber } from 'fp-ts/lib/Setoid'
+import * as S from 'fp-ts/lib/Set'
+import * as SM from 'fp-ts/lib/StrMap'
+
+describe('At', () => {
+  describe('atStrMap', () => {
+    const map = SM.singleton('key', 'value')
+    const at = atStrMap<string>().at('key')
+
+    it('get', () => {
+      assert.deepEqual(at.get(map), some('value'))
+    })
+
+    it('add', () => {
+      const newMap = at.set(some('NEW'))(map)
+
+      assert.deepEqual(newMap, SM.singleton('key', 'NEW'))
+    })
+
+    it('delete', () => {
+      const newMap = at.set(none)(map)
+
+      assert(SM.isEmpty(newMap))
+    })
+  })
+
+  describe('atSet', () => {
+    const set = S.singleton(3)
+    const at = atSet(setoidNumber).at(3)
+
+    it('get', () => {
+      assert.deepEqual(at.get(set), true)
+    })
+
+    it('add', () => {
+      const newSet = at.set(true)(set)
+
+      assert.deepEqual(newSet, set)
+    })
+
+    it('delete', () => {
+      const newSet = at.set(false)(set)
+
+      assert.deepEqual(newSet, new Set())
+    })
+  })
+})

--- a/test/Index.ts
+++ b/test/Index.ts
@@ -1,0 +1,55 @@
+import { indexArray } from '../src/Index/Array'
+import { indexStrMap } from '../src/Index/StrMap'
+import * as assert from 'assert'
+import { some } from 'fp-ts/lib/Option'
+import * as SM from 'fp-ts/lib/StrMap'
+
+describe('Index', () => {
+  describe('indexStrMap', () => {
+    const index = indexStrMap<string>().index('key')
+
+    it('get', () => {
+      const map = SM.singleton('key', 'value')
+
+      assert.deepEqual(index.getOption(map), some('value'))
+    })
+
+    it('set if there', () => {
+      const map = SM.singleton('key', 'value')
+      const newMap = index.set('new')(map)
+
+      assert.deepEqual(newMap, SM.singleton('key', 'new'))
+    })
+
+    it('leave if missing', () => {
+      const map = new SM.StrMap<string>({})
+      const newMap = index.set('new')(map)
+
+      assert.deepEqual(newMap, map)
+    })
+  })
+
+  describe('indexStrMap', () => {
+    const index = indexArray<string>().index(0)
+
+    it('get', () => {
+      const arr = ['test']
+
+      assert.deepEqual(index.getOption(arr), some('test'))
+    })
+
+    it('set if there', () => {
+      const arr = ['test']
+      const newArr = index.set('new')(arr)
+
+      assert.deepEqual(newArr, ['new'])
+    })
+
+    it('leave if missing', () => {
+      const arr: Array<string> = []
+      const newArr = index.set('new')(arr)
+
+      assert.deepEqual(newArr, arr)
+    })
+  })
+})


### PR DESCRIPTION
Thought I'd give this a try - I think I've understood correctly...
Added At for StrMap and Set based on the monocle module. Noticed that PureScript has `set` always with a `Maybe` - do we want that here instead?
Is it worth adding `atRecord` or `atOption` as PS does?
Wasn't sure about the composition stuff, would appreciate some guidance on that, then could probably look at doing `Index` too.