### PR TITLE
Add new `shallowCopy` function to more resiliently copy objects during lens operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monocle-ts",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1985,9 +1985,9 @@
       }
     },
     "fp-ts": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.0.0.tgz",
-      "integrity": "sha512-eXq3sOoJNS4aQJFSi8LWoz9TSLAdm9+TZqnj1aA55AC4fSltlGeOorJ3zQiQWcWFea3DdTXSEoUuAp97ObCI2Q=="
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/fp-ts/-/fp-ts-1.7.1.tgz",
+      "integrity": "sha512-7jAWAdc+TQ6qEm89VvwsHBliF93VxCzYXKr8Zr99hdVJ/eB+/fjNwWT3qkKI4i4PS89H8tRTe4h9/sFvHrf65Q=="
     },
     "fragment-cache": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/gcanti/monocle-ts",
   "dependencies": {
-    "fp-ts": "^1.0.0"
+    "fp-ts": "^1.7.1"
   },
   "devDependencies": {
     "@types/jest": "^22.2.2",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,49 @@
+export function shallowCopy<T, P>(object: T, newProperties?: P): T & P {
+  if (object == null) {
+    return object
+  }
+
+  // Copy array
+  if (Array.isArray(object)) {
+    const newArray = ([...object] as any) as T & P
+
+    if (newProperties == null) {
+      return newArray
+    }
+
+    const newPropertiesProperties = Object.getOwnPropertyDescriptors(newProperties)
+
+    for (const key in newPropertiesProperties) {
+      newArray[key] = newPropertiesProperties[key].value
+    }
+
+    return newArray
+  }
+
+  // Copy _raw_ object
+  if (Object.getPrototypeOf(object) === Object.prototype) {
+    if (newProperties == null) {
+      return { ...(object as any) }
+    }
+
+    return { ...(object as any), ...(newProperties as any) }
+  }
+
+  // Copy class instance, preserving prototype and preventing new properties
+  const newObjectPrototype = Object.getPrototypeOf(object)
+  const newObjectProperties = Object.getOwnPropertyDescriptors(object)
+
+  if (newProperties == null) {
+    return Object.create(newObjectPrototype, newObjectProperties)
+  }
+
+  const newPropertiesProperties = Object.getOwnPropertyDescriptors(newProperties)
+
+  for (const key in newPropertiesProperties) {
+    if (key in newObjectProperties) {
+      newObjectProperties[key].value = newPropertiesProperties[key].value
+    }
+  }
+
+  return Object.create(newObjectPrototype, newObjectProperties)
+}

--- a/test/Lens.ts
+++ b/test/Lens.ts
@@ -1,56 +1,88 @@
 import { Lens } from '../src'
 import * as assert from 'assert'
 
-interface Street {
-  num: number
-  name: string
-}
-interface Address {
-  city: string
-  street: Street
-}
-interface Company {
-  name: string
-  address: Address
-}
-interface Employee {
-  name: string
-  company: Company
-}
-
-const employee: Employee = {
-  name: 'john',
-  company: {
-    name: 'awesome inc',
-    address: {
-      city: 'london',
-      street: {
-        num: 23,
-        name: 'high street'
-      }
-    }
-  }
-}
-
-interface Person {
-  name: string
-  age: number
-  rememberMe: boolean
-}
-
 function capitalize(s: string): string {
   return s.substring(0, 1).toUpperCase() + s.substring(1)
 }
 
 describe('Lens', () => {
   it('fromPath', () => {
+    interface Street {
+      num: number
+      name: string
+    }
+
+    interface Address {
+      city: string
+      street: Street
+    }
+
+    interface Company {
+      name: string
+      address: Address
+    }
+
+    interface Employee {
+      name: string
+      company: Company
+    }
+
     const lens = Lens.fromPath<Employee, 'company', 'address', 'street', 'name'>([
       'company',
       'address',
       'street',
       'name'
     ])
-    assert.strictEqual(lens.modify(capitalize)(employee).company.address.street.name, 'High street')
+    const employee: Employee = {
+      name: 'john',
+      company: {
+        name: 'awesome inc',
+        address: {
+          city: 'london',
+          street: {
+            num: 23,
+            name: 'high street'
+          }
+        }
+      }
+    }
+    const newEmployee: Employee = lens.modify(capitalize)(employee)
+
+    assert.strictEqual(newEmployee.company.address.street.name, 'High street')
+
+    class Street {
+      constructor(public num: number, public name: string) {}
+    }
+
+    class Address {
+      constructor(public city: string, public street: Street) {}
+    }
+
+    class Company {
+      constructor(public name: string, public address: Address) {}
+    }
+
+    class Employee {
+      constructor(public name: string, public company: Company) {}
+    }
+
+    const classLens = Lens.fromPath<Employee, 'company', 'address', 'street', 'name'>([
+      'company',
+      'address',
+      'street',
+      'name'
+    ])
+    const employeeInstance = new Employee(
+      'john',
+      new Company('awesome inc', new Address('london', new Street(23, 'high street')))
+    )
+    const newEmployeeInstance = classLens.modify(capitalize)(employeeInstance)
+
+    assert(newEmployeeInstance instanceof Employee)
+    assert(newEmployeeInstance.company instanceof Company)
+    assert(newEmployeeInstance.company.address instanceof Address)
+    assert(newEmployeeInstance.company.address.street instanceof Street)
+    assert.strictEqual(newEmployeeInstance.company.address.street.name, 'High street')
   })
 
   it('fromNullableProp', () => {
@@ -63,20 +95,73 @@ describe('Lens', () => {
       foo: string
     }
 
-    const inner = Lens.fromNullableProp<Outer, Inner, 'inner'>('inner', { value: 0, foo: 'foo' })
-    const value = Lens.fromProp<Inner, 'value'>('value')
-    const lens = inner.compose(value)
+    const innerPropLens = Lens.fromNullableProp<Outer, Inner, 'inner'>('inner', { value: 0, foo: 'foo' })
+    const valuePropLens = Lens.fromProp<Inner, 'value'>('value')
+    const lens = innerPropLens.compose(valuePropLens)
 
-    assert.deepEqual(lens.set(1)({}), { inner: { value: 1, foo: 'foo' } })
+    const newOuter1: Outer = lens.set(1)({})
+
+    assert.deepEqual(newOuter1, { inner: { value: 1, foo: 'foo' } })
     assert.strictEqual(lens.get({}), 0)
-    assert.deepEqual(lens.set(1)({ inner: { value: 1, foo: 'bar' } }), { inner: { value: 1, foo: 'bar' } })
+
+    const newOuter2 = lens.set(1)({ inner: { value: 1, foo: 'bar' } })
+
+    assert.deepEqual(newOuter2, { inner: { value: 1, foo: 'bar' } })
     assert.strictEqual(lens.get({ inner: { value: 1, foo: 'bar' } }), 1)
+
+    class Outer {
+      constructor(public inner?: Inner) {}
+    }
+
+    class Inner {
+      constructor(public value: number, public foo: string) {}
+    }
+
+    const innerClassPropLens = Lens.fromNullableProp<Outer, Inner, 'inner'>('inner', new Inner(0, 'foo'))
+    const valueClassPropLens = Lens.fromProp<Inner, 'value'>('value')
+    const classLens = innerClassPropLens.compose(valueClassPropLens)
+
+    const newOuterInstance1 = classLens.set(1)(new Outer())
+
+    assert(newOuterInstance1 instanceof Outer)
+    assert.deepEqual(newOuterInstance1, new Outer(new Inner(1, 'foo')))
+    assert.strictEqual(classLens.get(new Outer()), 0)
+
+    const newOuterInstance2 = classLens.set(1)(new Outer(new Inner(1, 'bar')))
+
+    assert(newOuterInstance2 instanceof Outer)
+    assert.deepEqual(newOuterInstance2, new Outer(new Inner(1, 'bar')))
+    assert.strictEqual(classLens.get(new Outer(new Inner(1, 'bar'))), 1)
   })
 
   it('fromProps', () => {
-    const person: Person = { name: 'Giulio', age: 44, rememberMe: true }
+    interface Person {
+      name: string
+      age: number
+      rememberMe: boolean
+    }
+
     const lens = Lens.fromProps<Person>()(['name', 'age'])
+    const person: Person = { name: 'Giulio', age: 44, rememberMe: true }
+
     assert.deepEqual(lens.get(person), { name: 'Giulio', age: 44 })
-    assert.deepEqual(lens.set({ name: 'Guido', age: 47 })(person), { name: 'Guido', age: 47, rememberMe: true })
+
+    const newPerson = lens.set({ name: 'Guido', age: 47 })(person)
+
+    assert.deepEqual(newPerson, { name: 'Guido', age: 47, rememberMe: true })
+
+    class Person {
+      constructor(public name: string, public age: number, public rememberMe: boolean) {}
+    }
+
+    const classLens = Lens.fromProps<Person>()(['name', 'age'])
+    const personInstance = new Person('Giulio', 44, true)
+
+    assert.deepEqual(classLens.get(personInstance), { name: 'Giulio', age: 44 })
+
+    const newPersonInstance = classLens.set({ name: 'Guido', age: 47 })(personInstance)
+
+    assert(newPersonInstance instanceof Person)
+    assert.deepEqual(newPersonInstance, new Person('Guido', 47, true))
   })
 })

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert'
+import { shallowCopy } from '../src/util'
+
+describe('util', () => {
+  describe('shallowCopy', () => {
+    it('copy raw object as-is', () => {
+      const actual = shallowCopy({ foo: 1, bar: 'a' })
+      const expected = { foo: 1, bar: 'a' }
+
+      assert.deepEqual(actual, expected)
+    })
+
+    it('copy raw object and change existing properties', () => {
+      const actual = shallowCopy({ foo: 1, bar: 'a' }, { foo: 2, bar: 'b' })
+      const expected = { foo: 2, bar: 'b' }
+
+      assert.deepEqual(actual, expected)
+    })
+
+    it('copy raw object and add new properties', () => {
+      const actual = shallowCopy({ foo: 1, bar: 'a' }, { baz: true })
+      const expected = { foo: 1, bar: 'a', baz: true }
+
+      assert.deepEqual(actual, expected)
+    })
+
+    it('copy array as-is', () => {
+      const actual = shallowCopy([1, 'a'])
+      const expected = [1, 'a']
+
+      assert.deepEqual(actual, expected)
+      assert(Array.isArray(actual))
+    })
+
+    it('copy array and change existing properties', () => {
+      const actual = shallowCopy([1, 'a'], { 0: 2, 1: 'b' })
+      const expected = [2, 'b']
+
+      assert.deepEqual(actual, expected)
+      assert(Array.isArray(actual))
+    })
+
+    it('copy array and add new properties', () => {
+      const actual = shallowCopy([1, 'a'], { 2: true })
+      const expected = [1, 'a', true]
+
+      assert.deepEqual(actual, expected)
+      assert(Array.isArray(actual))
+    })
+
+    it('copy class instance as-is', () => {
+      class FooBar {
+        constructor(readonly foo: number, readonly bar: string) {}
+      }
+
+      const actual = shallowCopy(new FooBar(1, 'a'))
+      const expected = new FooBar(1, 'a')
+
+      assert.deepEqual(actual, expected)
+      assert(actual instanceof FooBar)
+    })
+
+    it('copy class instance and change existing properties', () => {
+      class FooBar {
+        constructor(readonly foo: number, readonly bar: string) {}
+      }
+
+      const actual = shallowCopy(new FooBar(1, 'a'), { foo: 2, bar: 'b' })
+      const expected = new FooBar(2, 'b')
+
+      assert.deepEqual(actual, expected)
+      assert(actual instanceof FooBar)
+    })
+
+    it("copy class instance but don't add new properties", () => {
+      class FooBar {
+        constructor(readonly foo: number, readonly bar: string) {}
+      }
+
+      const actual = shallowCopy(new FooBar(1, 'a'), { baz: true })
+      const expected = new FooBar(1, 'a')
+
+      assert.deepEqual(actual, expected)
+      assert(actual instanceof FooBar)
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "node",
     "forceConsistentCasingInFileNames": true,
     "suppressImplicitAnyIndexErrors": true,
-    "lib": ["es6"]
+    "lib": ["es2017"]
   },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
Fixes #52 