### PR TITLE
Added a function to handle type/subtype as a Prism.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import {
 import { Foldable, Foldable1, Foldable2, Foldable3, foldMap } from 'fp-ts/lib/Foldable'
 import { Traversable, Traversable1, Traversable2, Traversable3 } from 'fp-ts/lib/Traversable'
 import { Option, none, some, fromNullable, option, getFirstMonoid } from 'fp-ts/lib/Option'
-import { identity, constant, Predicate } from 'fp-ts/lib/function'
+import { identity, constant, Predicate, Refinement } from 'fp-ts/lib/function'
 import { identity as id } from 'fp-ts/lib/Identity'
 import { Const, getApplicative } from 'fp-ts/lib/Const'
 
@@ -303,6 +303,10 @@ export class Prism<S, A> {
 
   static fromPredicate<A>(predicate: Predicate<A>): Prism<A, A> {
     return new Prism(s => (predicate(s) ? some(s) : none), a => a)
+  }
+
+  static fromRefinement<S, A extends S>(refinement: Refinement<S, A>): Prism<S, A> {
+    return new Prism(s => (refinement(s) ? some(s) : none), a => a)
   }
 
   static some<A>(): Prism<Option<A>, A> {

--- a/test/Prism.ts
+++ b/test/Prism.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert'
 import { Prism } from '../src'
+import { Refinement } from 'fp-ts/lib/function'
 import { none, some } from 'fp-ts/lib/Option'
 
 describe('Prism', () => {
@@ -7,6 +8,25 @@ describe('Prism', () => {
     const prism = Prism.fromPredicate<number>(n => n % 1 === 0)
     assert.deepEqual(prism.getOption(1), some(1))
     assert.deepEqual(prism.getOption(1.1), none)
+  })
+
+  it('fromRefinement', () => {
+    interface A {
+      type: 'A'
+      a: string
+    }
+    interface B {
+      type: 'B'
+      b: number
+    }
+    type U = A | B
+
+    const isA: Refinement<U, A> = (u): u is A => u.type === 'A'
+
+    const prism = Prism.fromRefinement(isA)
+    const toUpperCase = (a: A): A => ({ type: 'A', a: a.a.toUpperCase() })
+    assert.deepEqual(prism.modify(toUpperCase)({ type: 'A', a: 'foo' }), { type: 'A', a: 'FOO' })
+    assert.deepEqual(prism.modify(toUpperCase)({ type: 'B', b: 1 }), { type: 'B', b: 1 })
   })
 
   it('some', () => {


### PR DESCRIPTION
I added a static function to handle the case when you want to have a Prism relation between a type a specialization. The most likely case being between a union type (not necessarily tagged!) and a member type.