### PR TITLE
Add appendPredicate method to Prism

### DIFF
--- a/docs/modules/index.ts.md
+++ b/docs/modules/index.ts.md
@@ -129,6 +129,7 @@ Added in v1.0.0
     - [composeIso (method)](#composeiso-method-5)
     - [composeLens (method)](#composelens-method-5)
     - [composeGetter (method)](#composegetter-method-5)
+    - [appendPredicate (method)](#appendpredicate-method)
     - [\_tag (property)](#_tag-property-7)
   - [Setter (class)](#setter-class)
     - [set (method)](#set-method-1)
@@ -1699,6 +1700,16 @@ composeGetter<B>(ab: Getter<A, B>): Fold<S, B>
 ```
 
 Added in v1.0.0
+
+### appendPredicate (method)
+
+**Signature**
+
+```ts
+appendPredicate(p: Predicate<S>): Prism<S, A>
+```
+
+Added in v2.2.0
 
 ### \_tag (property)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { Applicative, Applicative1, Applicative2, Applicative3, Applicative2C } 
 import { Foldable, Foldable1, Foldable2, Foldable3 } from 'fp-ts/lib/Foldable'
 import { Traversable, Traversable1, Traversable2, Traversable3 } from 'fp-ts/lib/Traversable'
 import { Option, none, some, fromNullable, getFirstMonoid, fromPredicate, isNone, option } from 'fp-ts/lib/Option'
-import { identity, constant, Predicate, Refinement } from 'fp-ts/lib/function'
+import { identity, constant, flow, Predicate, Refinement } from 'fp-ts/lib/function'
 import { identity as id } from 'fp-ts/lib/Identity'
 import { getApplicative, make } from 'fp-ts/lib/Const'
 import { getMonoid } from 'fp-ts/lib/Array'
@@ -735,6 +735,13 @@ export class Prism<S, A> {
    */
   composeGetter<B>(ab: Getter<A, B>): Fold<S, B> {
     return this.asFold().compose(ab.asFold())
+  }
+
+  /**
+   * @since 2.2.0
+   */
+  appendPredicate(p: Predicate<S>): Prism<S, A> {
+    return this.compose(Prism.fromPredicate(flow(this.reverseGet, p)))
   }
 }
 

--- a/test/Prism.ts
+++ b/test/Prism.ts
@@ -91,4 +91,11 @@ describe('Prism', () => {
     assert.deepStrictEqual(composition2.getOption({ type: 'A', a: 'a' }), composition1.getOption({ type: 'A', a: 'a' }))
     assert.deepStrictEqual(composition2.reverseGet(1), composition1.reverseGet(1))
   })
+
+  it('appendPredicate', () => {
+    const prism = Prism.fromPredicate<number>((n) => n % 2 === 0).appendPredicate((n) => n % 3 === 0)
+    assert.deepStrictEqual(prism.getOption(2), none)
+    assert.deepStrictEqual(prism.getOption(3), none)
+    assert.deepStrictEqual(prism.getOption(6), some(6))
+  })
 })


### PR DESCRIPTION
This PR provides `appendPredicate`, which creates new prism restricted with a given predicate.
This function is usefl when we want to shrink a codomain of an existing prism.

```typescript
// "base" prism
const nonEmptyString = Prism.fromPredicate<string>(s => s.length > 0);

// extensions
const maxLength512 = nonEmptyString.appendPredicate(s => s.length <= 512);
const maxLength1024 = nonEmptyString.appendPredicate(s => s.length <= 1024);
```