### PR TITLE
feat: fluent API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib
 es6
 dev
 coverage
+.idea

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,0 +1,37 @@
+import { Option } from 'fp-ts/lib/Option'
+import { fromTraversable, Lens, Optional } from '../src'
+import { array } from 'fp-ts/lib/Array'
+import { record } from 'fp-ts/lib/Record'
+import { indexArray } from '../src/Index/Array'
+
+interface NestedValue {
+  baz: string
+}
+interface Nested extends Array<NestedValue> {}
+interface Value {
+  nested: Option<Nested>
+}
+interface Foo extends Record<string, Value> {}
+interface Item {
+  readonly foo: Foo
+}
+interface Items extends Array<Item> {}
+interface Data {
+  readonly items: Items
+}
+
+export const classicSecondBaz = Lens.fromProp<Data>()('items')
+  .composeTraversal(fromTraversable(array)())
+  .composeLens(Lens.fromProp<Item>()('foo'))
+  .composeTraversal(fromTraversable(record)())
+  .composeOptional(Optional.fromOptionProp<Value>()('nested'))
+  .composeOptional(indexArray<NestedValue>().index(2))
+  .composeLens(Lens.fromProp<NestedValue>()('baz'))
+
+export const fluentSecondBaz = Lens.fromProp<Data>()('items')
+  .traverse(array)
+  .prop('foo')
+  .traverse(record)
+  .optionProp('nested')
+  .index(2)
+  .prop('baz')


### PR DESCRIPTION
Hi!

This PR contains partial implementation of a fluent API for some of optics.
The fluent API adds some commonly-used methods directly to instances.

Here's an example of what is possible with this API and how amount of code is reduced in comparison with original API.

```typescript
// /test/test.ts
import { Option } from 'fp-ts/lib/Option'
import { fromTraversable, Lens, Optional } from '../src'
import { array } from 'fp-ts/lib/Array'
import { record } from 'fp-ts/lib/Record'
import { indexArray } from '../src/Index/Array'

interface NestedValue {
  baz: string
}
interface Nested extends Array<NestedValue> {}
interface Value {
  nested: Option<Nested>
}
interface Foo extends Record<string, Value> {}
interface Item {
  readonly foo: Foo
}
interface Items extends Array<Item> {}
interface Data {
  readonly items: Items
}

const classicSecondBaz = Lens.fromProp<Data>()('items')
  .composeTraversal(fromTraversable(array)())
  .composeLens(Lens.fromProp<Item>()('foo'))
  .composeTraversal(fromTraversable(record)())
  .composeOptional(Optional.fromOptionProp<Value>()('nested'))
  .composeOptional(indexArray<NestedValue>().index(2))
  .composeLens(Lens.fromProp<NestedValue>()('baz'))

const fluentSecondBaz = Lens.fromProp<Data>()('items')
  .traverse(array)
  .prop('foo')
  .traverse(record)
  .optionProp('nested')
  .index(2)
  .prop('baz')
```

@gcanti The changes are non-breaking (API is just extended). If you are ok with the proposed changes I'll update the PR with similar changes to all available optics.

TODO:
 - [ ] remove `test.ts`
 - [ ] update all optics
 - [ ] add `traverse` overloadings