### PR TITLE
Fix link to Scala's Monocle

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Motivation
 
-(Adapted from [monocle site](http://julien-truffaut.github.io/Monocle/))
+(Adapted from [monocle site](https://www.optics.dev/Monocle/))
 
 Modifying immutable nested object in JavaScript is verbose which makes code difficult to understand and reason about.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ title: Home
 
 # Motivation
 
-(Adapted from [monocle site](http://julien-truffaut.github.io/Monocle/))
+(Adapted from [monocle site](https://www.optics.dev/Monocle/))
 
 Modifying immutable nested object in JavaScript is verbose which makes code difficult to understand and reason about.
 


### PR DESCRIPTION
Seems like Monocle library for Scala moved from personal github repo to https://github.com/optics-dev/ and the website moved as well to https://www.optics.dev/Monocle/.