### PR TITLE
fix Lens.fromProp examples

### DIFF
--- a/examples/Lens.ts
+++ b/examples/Lens.ts
@@ -82,6 +82,6 @@ type PersonType = {
 
 const person: PersonType = { name: 'Giulio', age: 42 }
 
-const age = Lens.fromProp<PersonType, 'age'>('age')
+const age = Lens.fromProp<PersonType>()('age')
 
 console.log(age.set(43)(person)) // => { name: 'Giulio', age: 43 }

--- a/examples/Optional.ts
+++ b/examples/Optional.ts
@@ -21,7 +21,7 @@ interface Person {
   surname: Option<string>
 }
 
-const surname = Lens.fromProp<Person, 'surname'>('surname').composePrism(Prism.some<string>())
+const surname = Lens.fromProp<Person>()('surname').composePrism(Prism.some<string>())
 
 const p: Person = { name: 'Giulio', surname: none }
 

--- a/examples/introduction.ts
+++ b/examples/introduction.ts
@@ -51,10 +51,10 @@ console.log(JSON.stringify(employee2, null, 2))
 
 import { Lens, Optional } from '../src'
 
-const company = Lens.fromProp<Employee, 'company'>('company')
-const address = Lens.fromProp<Company, 'address'>('address')
-const street = Lens.fromProp<Address, 'street'>('street')
-const name = Lens.fromProp<Street, 'name'>('name')
+const company = Lens.fromProp<Employee>()('company')
+const address = Lens.fromProp<Company>()('address')
+const street = Lens.fromProp<Address>()('street')
+const name = Lens.fromProp<Street>()('name')
 
 import { some, none } from 'fp-ts/lib/Option'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monocle-ts",
-  "version": "2.3.0",
+  "version": "2.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The `Lens.fromProp` code in the `examples` directory must apply to an old version.

I've changed it from 

`const company = Lens.fromProp<Employee, 'company'>('company')`

to

`const company = Lens.fromProp<Employee>()('company')`

This code is still broke in `examples/fold` directory:

`const fold2 = fromFoldable(either)<boolean, string>()`