### PR TITLE
Bind Fold#headOption method to this

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1361,6 +1361,7 @@ export class Fold<S, A> {
     this.exist = foldMap(monoidAny)
     this.all = foldMap(monoidAll)
     this.foldMapFirst = foldMap(getFirstMonoid())
+    this.headOption = this.headOption.bind(this)
   }
 
   /**


### PR DESCRIPTION
Allows the usage of the `headOption` method when used as reference for example in a `pipe` statement. Without the bind the `this` context gets lost and an error like this occurs:

```
Uncaught TypeError: Cannot read property 'find' of undefined
  at push.../../node_modules/monocle-ts/es6/index.js.Fold.headOption
```