### PR TITLE
add Refinement overload to findFirst

### DIFF
--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -235,9 +235,13 @@ export function traverse<T extends URIS>(T: Traversable1<T>): <S, A>(sta: Lens<S
  * @category combinators
  * @since 2.3.2
  */
-export const findFirst: <A>(predicate: Predicate<A>) => <S>(sa: Lens<S, ReadonlyArray<A>>) => Optional<S, A> =
-  /*#__PURE__*/
-  flow(_.findFirst, composeOptional)
+export function findFirst<A, B extends A>(
+  refinement: Refinement<A, B>
+): <S>(sa: Lens<S, ReadonlyArray<A>>) => Optional<S, B>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Lens<S, ReadonlyArray<A>>) => Optional<S, A>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Lens<S, ReadonlyArray<A>>) => Optional<S, A> {
+  return flow(_.findFirst, composeOptional)(predicate)
+}
 
 // -------------------------------------------------------------------------------------
 // pipeables

--- a/src/Optional.ts
+++ b/src/Optional.ts
@@ -222,9 +222,13 @@ export function traverse<T extends URIS>(T: Traversable1<T>): <S, A>(sta: Option
  * @category combinators
  * @since 2.3.2
  */
-export const findFirst: <A>(predicate: Predicate<A>) => <S>(sa: Optional<S, ReadonlyArray<A>>) => Optional<S, A> =
-  /*#__PURE__*/
-  flow(_.findFirst, compose)
+export function findFirst<A, B extends A>(
+  refinement: Refinement<A, B>
+): <S>(sa: Optional<S, ReadonlyArray<A>>) => Optional<S, B>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Optional<S, ReadonlyArray<A>>) => Optional<S, A>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Optional<S, ReadonlyArray<A>>) => Optional<S, A> {
+  return flow(_.findFirst, compose)(predicate)
+}
 
 // -------------------------------------------------------------------------------------
 // pipeables

--- a/src/Prism.ts
+++ b/src/Prism.ts
@@ -258,9 +258,13 @@ export function traverse<T extends URIS>(T: Traversable1<T>): <S, A>(sta: Prism<
  * @category combinators
  * @since 2.3.2
  */
-export const findFirst: <A>(predicate: Predicate<A>) => <S>(sa: Prism<S, ReadonlyArray<A>>) => Optional<S, A> =
-  /*#__PURE__*/
-  flow(_.findFirst, composeOptional)
+export function findFirst<A, B extends A>(
+  refinement: Refinement<A, B>
+): <S>(sa: Prism<S, ReadonlyArray<A>>) => Optional<S, B>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Prism<S, ReadonlyArray<A>>) => Optional<S, A>
+export function findFirst<A>(predicate: Predicate<A>): <S>(sa: Prism<S, ReadonlyArray<A>>) => Optional<S, A> {
+  return flow(_.findFirst, composeOptional)(predicate)
+}
 
 // -------------------------------------------------------------------------------------
 // pipeables


### PR DESCRIPTION
The `Refinement` `findFirst` overload  would be useful when dealing with arrays of union types.
Right now the workaround is to folllow a `findFirst` with a `filter`:

```
    pipe(
        ...,
        O.findFirst(Vehicle.is.Bicycle),
        O.filter(Vehicle.is.Bicycle),
        ...
    )
``` 

