### PR TITLE
[OptionalFromPath] Type Issue fix for 5 arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -755,7 +755,7 @@ export interface OptionalFromPath<S> {
     K2 extends keyof NonNullable<S[K1]>,
     K3 extends keyof NonNullable<NonNullable<S[K1]>[K2]>,
     K4 extends keyof NonNullable<NonNullable<NonNullable<S[K1]>[K2]>[K3]>,
-    K5 extends keyof NonNullable<NonNullable<NonNullable<S[K1]>[K2]>[K3]>[K4]
+    K5 extends keyof NonNullable<NonNullable<NonNullable<NonNullable<S[K1]>[K2]>[K3]>[K4]>
   >(
     path: [K1, K2, K3, K4, K5]
   ): Optional<S, NonNullable<NonNullable<NonNullable<NonNullable<NonNullable<S[K1]>[K2]>[K3]>[K4]>[K5]>>


### PR DESCRIPTION
When 5 fields are provided into `OptionalFromPath`, the `K4` generic should also be wrapped with `NonNullable`, same as the rest.

Discovered it by having my own use case with 5 arguments, which caused an unexpected build error.