### PR TITLE
Add `non` and `anon`

### DIFF
--- a/docs/modules/Iso.ts.md
+++ b/docs/modules/Iso.ts.md
@@ -53,8 +53,10 @@ Added in v2.3.0
   - [composePrism](#composeprism)
   - [composeTraversal](#composetraversal)
 - [constructors](#constructors)
+  - [anon](#anon)
   - [id](#id)
   - [iso](#iso)
+  - [non](#non)
   - [reverse](#reverse)
 - [converters](#converters)
   - [asLens](#aslens)
@@ -382,6 +384,19 @@ Added in v2.3.8
 
 # constructors
 
+## anon
+
+Create an `Iso<Option<A>, A>` given a `Predicate<A>` and some value to
+correspond to `none`.
+
+**Signature**
+
+```ts
+export declare const anon: <A>(a: A) => (pred: Predicate<A>) => Iso<Option<A>, A>
+```
+
+Added in v2.4.0
+
 ## id
 
 **Signature**
@@ -401,6 +416,55 @@ export declare const iso: <S, A>(get: (s: S) => A, reverseGet: (a: A) => S) => I
 ```
 
 Added in v2.3.8
+
+## non
+
+Create an `Iso<Option<A>, A>` given an `Eq<A>` and some value to correspond
+to `none`.
+
+**Signature**
+
+```ts
+export declare const non: <A>(eq: Eq<A>) => (a: A) => Iso<Option<A>, A>
+```
+
+**Example**
+
+```ts
+import { eqNumber } from 'fp-ts/Eq'
+import { pipe } from 'fp-ts/function'
+import { non } from 'monocle-ts/Iso'
+import { atKey, composeIso, id } from 'monocle-ts/Lens'
+
+// Can be used to have "defaults"
+const a = pipe(id<Record<string, number>>(), atKey('a'), composeIso(non(eqNumber)(0)))
+assert.deepStrictEqual(a.get({}), 0)
+assert.deepStrictEqual(a.get({ a: 1 }), 1)
+assert.deepStrictEqual(a.set(0)({ a: 1 }), {})
+assert.deepStrictEqual(a.set(1)({}), { a: 1 })
+```
+
+**Example**
+
+```ts
+import { eqString } from 'fp-ts/Eq'
+import { pipe } from 'fp-ts/function'
+import { none } from 'fp-ts/Option'
+import { getEq } from 'fp-ts/ReadonlyRecord'
+import { non } from 'monocle-ts/Iso'
+import { atKey, composeIso, id } from 'monocle-ts/Lens'
+
+// Or delete surrounding structure when a nested value becomes empty
+const b = pipe(
+  id<Record<string, Record<string, string>>>(),
+  atKey('hello'),
+  composeIso(non(getEq(eqString))({})),
+  atKey('world')
+)
+assert.deepStrictEqual(b.set(none)({ hello: { world: '!' } }), {})
+```
+
+Added in v2.4.0
 
 ## reverse
 

--- a/test/Iso.ts
+++ b/test/Iso.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert'
+import * as Eq from 'fp-ts/lib/Eq'
 import * as Id from 'fp-ts/lib/Identity'
 import * as O from 'fp-ts/lib/Option'
 import { pipe } from 'fp-ts/lib/pipeable'
@@ -291,5 +292,21 @@ describe('Iso', () => {
     U.deepStrictEqual(optional.getOption({ a: [-1, 2] }), O.some(2))
     U.deepStrictEqual(optional.set(1)({ a: [-1] }), { a: [-1] })
     U.deepStrictEqual(optional.set(3)({ a: [-1, 2] }), { a: [-1, 3] })
+  })
+
+  it('non', () => {
+    const sa = _.non(Eq.eqNumber)(0)
+    U.deepStrictEqual(sa.get(O.some(1)), 1)
+    U.deepStrictEqual(sa.get(O.none), 0)
+    U.deepStrictEqual(sa.reverseGet(0), O.none)
+    U.deepStrictEqual(sa.reverseGet(1), O.some(1))
+  })
+
+  it('anon', () => {
+    const sa = _.anon(0)((a) => a === 0)
+    U.deepStrictEqual(sa.get(O.some(1)), 1)
+    U.deepStrictEqual(sa.get(O.none), 0)
+    U.deepStrictEqual(sa.reverseGet(0), O.none)
+    U.deepStrictEqual(sa.reverseGet(1), O.some(1))
   })
 })


### PR DESCRIPTION
This adds [`non`](https://hackage.haskell.org/package/lens-5.0.1/docs/Control-Lens-Iso.html#v:non) and [`anon`](https://hackage.haskell.org/package/lens-5.0.1/docs/Control-Lens-Iso.html#v:anon).

I think this will almost always be used with `composeIso` from some more complex optic type, so it might be best to add a combinator version to those modules (essentially just `export const non = eq => a => composeIso(non_(eq)(a))`); what do you think?