### PR TITLE
Add missing pure annotations

### DIFF
--- a/src/Iso.ts
+++ b/src/Iso.ts
@@ -280,7 +280,7 @@ export const atKey = (key: string): (<S, A>(sa: Iso<S, ReadonlyRecord<string, A>
  */
 export const some: <S, A>(soa: Iso<S, Option<A>>) => Prism<S, A> =
   /*#__PURE__*/
-  composePrism(_.prismSome())
+  composePrism(/*#__PURE__*/ _.prismSome())
 
 /**
  * Return a `Prism` from a `Iso` focused on the `Right` of a `Either` type.
@@ -290,7 +290,7 @@ export const some: <S, A>(soa: Iso<S, Option<A>>) => Prism<S, A> =
  */
 export const right: <S, E, A>(sea: Iso<S, Either<E, A>>) => Prism<S, A> =
   /*#__PURE__*/
-  composePrism(_.prismRight())
+  composePrism(/*#__PURE__*/ _.prismRight())
 
 /**
  * Return a `Prism` from a `Iso` focused on the `Left` of a `Either` type.
@@ -300,7 +300,7 @@ export const right: <S, E, A>(sea: Iso<S, Either<E, A>>) => Prism<S, A> =
  */
 export const left: <S, E, A>(sea: Iso<S, Either<E, A>>) => Prism<S, E> =
   /*#__PURE__*/
-  composePrism(_.prismLeft())
+  composePrism(/*#__PURE__*/ _.prismLeft())
 
 /**
  * Return a `Traversal` from a `Iso` focused on a `Traversable`.

--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -263,7 +263,7 @@ export const atKey: (key: string) => <S, A>(sa: Lens<S, ReadonlyRecord<string, A
  */
 export const some: <S, A>(soa: Lens<S, Option<A>>) => Optional<S, A> =
   /*#__PURE__*/
-  composePrism(_.prismSome())
+  composePrism(/*#__PURE__*/ _.prismSome())
 
 /**
  * Return a `Optional` from a `Lens` focused on the `Right` of a `Either` type.
@@ -273,7 +273,7 @@ export const some: <S, A>(soa: Lens<S, Option<A>>) => Optional<S, A> =
  */
 export const right: <S, E, A>(sea: Lens<S, Either<E, A>>) => Optional<S, A> =
   /*#__PURE__*/
-  composePrism(_.prismRight())
+  composePrism(/*#__PURE__*/ _.prismRight())
 
 /**
  * Return a `Optional` from a `Lens` focused on the `Left` of a `Either` type.
@@ -283,7 +283,7 @@ export const right: <S, E, A>(sea: Lens<S, Either<E, A>>) => Optional<S, A> =
  */
 export const left: <S, E, A>(sea: Lens<S, Either<E, A>>) => Optional<S, E> =
   /*#__PURE__*/
-  composePrism(_.prismLeft())
+  composePrism(/*#__PURE__*/ _.prismLeft())
 
 /**
  * Return a `Traversal` from a `Lens` focused on a `Traversable`.

--- a/src/Optional.ts
+++ b/src/Optional.ts
@@ -201,7 +201,7 @@ export function modifyF<F>(
  */
 export const fromNullable: <S, A>(sa: Optional<S, A>) => Optional<S, NonNullable<A>> =
   /*#__PURE__*/
-  compose(_.prismAsOptional(_.prismFromNullable()))
+  compose(/*#__PURE__*/ _.prismAsOptional(/*#__PURE__*/ _.prismFromNullable()))
 
 /**
  * @category combinators
@@ -286,7 +286,7 @@ export const atKey = (key: string) => <S, A>(sa: Optional<S, ReadonlyRecord<stri
  */
 export const some: <S, A>(soa: Optional<S, Option<A>>) => Optional<S, A> =
   /*#__PURE__*/
-  compose(_.prismAsOptional(_.prismSome()))
+  compose(/*#__PURE__*/ _.prismAsOptional(/*#__PURE__*/ _.prismSome()))
 
 /**
  * Return a `Optional` from a `Optional` focused on the `Right` of a `Either` type.
@@ -296,7 +296,7 @@ export const some: <S, A>(soa: Optional<S, Option<A>>) => Optional<S, A> =
  */
 export const right: <S, E, A>(sea: Optional<S, Either<E, A>>) => Optional<S, A> =
   /*#__PURE__*/
-  compose(_.prismAsOptional(_.prismRight()))
+  compose(/*#__PURE__*/ _.prismAsOptional(/*#__PURE__*/ _.prismRight()))
 
 /**
  * Return a `Optional` from a `Optional` focused on the `Left` of a `Either` type.
@@ -306,7 +306,7 @@ export const right: <S, E, A>(sea: Optional<S, Either<E, A>>) => Optional<S, A> 
  */
 export const left: <S, E, A>(sea: Optional<S, Either<E, A>>) => Optional<S, E> =
   /*#__PURE__*/
-  compose(_.prismAsOptional(_.prismLeft()))
+  compose(/*#__PURE__*/ _.prismAsOptional(/*#__PURE__*/ _.prismLeft()))
 
 /**
  * Return a `Traversal` from a `Optional` focused on a `Traversable`.

--- a/src/Prism.ts
+++ b/src/Prism.ts
@@ -208,7 +208,7 @@ export function modifyF<F>(
  */
 export const fromNullable: <S, A>(sa: Prism<S, A>) => Prism<S, NonNullable<A>> =
   /*#__PURE__*/
-  compose(_.prismFromNullable())
+  compose(/*#__PURE__*/ _.prismFromNullable())
 
 /**
  * @category combinators
@@ -293,7 +293,7 @@ export const atKey = (key: string) => <S, A>(sa: Prism<S, ReadonlyRecord<string,
  */
 export const some: <S, A>(soa: Prism<S, Option<A>>) => Prism<S, A> =
   /*#__PURE__*/
-  compose(_.prismSome())
+  compose(/*#__PURE__*/ _.prismSome())
 
 /**
  * Return a `Prism` from a `Prism` focused on the `Right` of a `Either` type.
@@ -303,7 +303,7 @@ export const some: <S, A>(soa: Prism<S, Option<A>>) => Prism<S, A> =
  */
 export const right: <S, E, A>(sea: Prism<S, Either<E, A>>) => Prism<S, A> =
   /*#__PURE__*/
-  compose(_.prismRight())
+  compose(/*#__PURE__*/ _.prismRight())
 
 /**
  * Return a `Prism` from a `Prism` focused on the `Left` of a `Either` type.
@@ -313,7 +313,7 @@ export const right: <S, E, A>(sea: Prism<S, Either<E, A>>) => Prism<S, A> =
  */
 export const left: <S, E, A>(sea: Prism<S, Either<E, A>>) => Prism<S, E> =
   /*#__PURE__*/
-  compose(_.prismLeft())
+  compose(/*#__PURE__*/ _.prismLeft())
 
 /**
  * Return a `Traversal` from a `Prism` focused on a `Traversable`.

--- a/src/Traversal.ts
+++ b/src/Traversal.ts
@@ -257,7 +257,7 @@ export const atKey = (key: string) => <S, A>(sa: Traversal<S, ReadonlyRecord<str
  */
 export const some: <S, A>(soa: Traversal<S, Option<A>>) => Traversal<S, A> =
   /*#__PURE__*/
-  compose(_.prismAsTraversal(_.prismSome()))
+  compose(/*#__PURE__*/ _.prismAsTraversal(/*#__PURE__*/ _.prismSome()))
 
 /**
  * Return a `Traversal` from a `Traversal` focused on the `Right` of a `Either` type.
@@ -267,7 +267,7 @@ export const some: <S, A>(soa: Traversal<S, Option<A>>) => Traversal<S, A> =
  */
 export const right: <S, E, A>(sea: Traversal<S, Either<E, A>>) => Traversal<S, A> =
   /*#__PURE__*/
-  compose(_.prismAsTraversal(_.prismRight()))
+  compose(/*#__PURE__*/ _.prismAsTraversal(/*#__PURE__*/ _.prismRight()))
 
 /**
  * Return a `Traversal` from a `Traversal` focused on the `Left` of a `Either` type.
@@ -277,7 +277,7 @@ export const right: <S, E, A>(sea: Traversal<S, Either<E, A>>) => Traversal<S, A
  */
 export const left: <S, E, A>(sea: Traversal<S, Either<E, A>>) => Traversal<S, E> =
   /*#__PURE__*/
-  compose(_.prismAsTraversal(_.prismLeft()))
+  compose(/*#__PURE__*/ _.prismAsTraversal(/*#__PURE__*/ _.prismLeft()))
 
 /**
  * Return a `Traversal` from a `Traversal` focused on a `Traversable`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -741,7 +741,9 @@ export class Prism<S, A> {
   }
 }
 
-const somePrism = new Prism<Option<any>, any>(identity, some)
+const somePrism =
+  /*#__PURE__*/
+  new Prism<Option<any>, any>(identity, some)
 
 type OptionPropertyNames<S> = { [K in keyof S]-?: S[K] extends Option<any> ? K : never }[keyof S]
 type OptionPropertyType<S, K extends OptionPropertyNames<S>> = S[K] extends Option<infer A> ? A : never


### PR DESCRIPTION
We also need to add pure annotations to the classes defined in `index.js`, however we can't add the pure annotation in the correct position because these are transpiled to IIFEs.

For example: https://github.com/gcanti/monocle-ts/blob/9bd7fa62e97f96c92c7ac7f4be9de3752842e5ee/src/index.ts#L1465

This will become:

```js
var Setter = /** @class */ (function () {
    function Setter() {
    }
    return Setter;
}());
export { Setter };
```

The pure annotation needs to be added like so:

```diff
-var Setter = /** @class */ (function () {
+var Setter = /** @class */ /*#__PURE__*/ (function () {
```

I believe this can be solved by using [a Babel plugin](https://github.com/Andarist/babel-plugin-annotate-pure-calls) that adds the pure annotation to output of TypeScript. Alternatively, we can disable class transpilation.

---

Pure annotations are very easy to miss and hard to get right, so perhaps we should automate this across the fp-ts ecosystem, using something like one of these tools. WDYT @gcanti?

- https://github.com/Andarist/babel-plugin-annotate-pure-calls
- https://github.com/morlay/babel-plugin-pure-calls-annotation