### PR TITLE
pick & omit

### DIFF
--- a/docs/modules/Iso.ts.md
+++ b/docs/modules/Iso.ts.md
@@ -40,11 +40,13 @@ Added in v2.3.0
   - [left](#left)
   - [modify](#modify)
   - [modifyF](#modifyf)
+  - [omit](#omit)
+  - [pick](#pick)
   - [prop](#prop)
-  - [props](#props)
   - [right](#right)
   - [some](#some)
   - [traverse](#traverse)
+  - [~~props~~](#props)
 - [compositions](#compositions)
   - [compose](#compose)
   - [composeIso](#composeiso)
@@ -242,6 +244,39 @@ export declare function modifyF<F>(
 
 Added in v2.3.5
 
+## omit
+
+Return a `Lens` from a `Iso` and a list of props to remove.
+A value-level 'Omit' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const omit: <A, P extends keyof A>(
+  props_0: P,
+  ...props_1: P[]
+) => <S>(sa: Iso<S, A>) => Lens<S, { [K in Exclude<keyof A, P>]: A[K] }>
+```
+
+Added in v2.3.13
+
+## pick
+
+Return a `Lens` from a `Iso` and a list of props.
+A value-level 'Pick' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const pick: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Iso<S, A>) => Lens<S, { [K in P]: A[K] }>
+```
+
+Added in v2.3.13
+
 ## prop
 
 Return a `Lens` from a `Iso` and a prop.
@@ -250,22 +285,6 @@ Return a `Lens` from a `Iso` and a prop.
 
 ```ts
 export declare const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Iso<S, A>) => Lens<S, A[P]>
-```
-
-Added in v2.3.8
-
-## props
-
-Return a `Lens` from a `Iso` and a list of props.
-
-**Signature**
-
-```ts
-export declare const props: <A, P extends keyof A>(
-  props_0: P,
-  props_1: P,
-  ...props_2: P[]
-) => <S>(sa: Iso<S, A>) => Lens<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.8
@@ -302,6 +321,22 @@ Return a `Traversal` from a `Iso` focused on a `Traversable`.
 
 ```ts
 export declare function traverse<T extends URIS>(T: Traversable1<T>): <S, A>(sta: Iso<S, Kind<T, A>>) => Traversal<S, A>
+```
+
+Added in v2.3.8
+
+## ~~props~~
+
+Use `fromStruct` instead.
+
+**Signature**
+
+```ts
+export declare const props: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Iso<S, A>) => Lens<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.8

--- a/docs/modules/Lens.ts.md
+++ b/docs/modules/Lens.ts.md
@@ -44,11 +44,13 @@ Added in v2.3.0
   - [left](#left)
   - [modify](#modify)
   - [modifyF](#modifyf)
+  - [omit](#omit)
+  - [pick](#pick)
   - [prop](#prop)
-  - [props](#props)
   - [right](#right)
   - [some](#some)
   - [traverse](#traverse)
+  - [~~props~~](#props)
 - [compositions](#compositions)
   - [compose](#compose)
   - [composeIso](#composeiso)
@@ -243,6 +245,39 @@ export declare function modifyF<F>(
 
 Added in v2.3.5
 
+## omit
+
+Return a `Lens` from a `Lens` and a list of props to remove.
+A value-level 'Omit' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const omit: <A, P extends keyof A>(
+  props_0: P,
+  ...props_1: P[]
+) => <S>(sa: Lens<S, A>) => Lens<S, { [K in Exclude<keyof A, P>]: A[K] }>
+```
+
+Added in v2.3.13
+
+## pick
+
+Return a `Lens` from a `Lens` and a list of props.
+A value-level 'Pick' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const pick: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Lens<S, A>) => Lens<S, { [K in P]: A[K] }>
+```
+
+Added in v2.3.13
+
 ## prop
 
 Return a `Lens` from a `Lens` and a prop.
@@ -251,22 +286,6 @@ Return a `Lens` from a `Lens` and a prop.
 
 ```ts
 export declare const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Lens<S, A>) => Lens<S, A[P]>
-```
-
-Added in v2.3.0
-
-## props
-
-Return a `Lens` from a `Lens` and a list of props.
-
-**Signature**
-
-```ts
-export declare const props: <A, P extends keyof A>(
-  props_0: P,
-  props_1: P,
-  ...props_2: P[]
-) => <S>(sa: Lens<S, A>) => Lens<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0
@@ -305,6 +324,22 @@ Return a `Traversal` from a `Lens` focused on a `Traversable`.
 export declare function traverse<T extends URIS>(
   T: Traversable1<T>
 ): <S, A>(sta: Lens<S, Kind<T, A>>) => Traversal<S, A>
+```
+
+Added in v2.3.0
+
+## ~~props~~
+
+Use `fromStruct` instead.
+
+**Signature**
+
+```ts
+export declare const props: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Lens<S, A>) => Lens<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0

--- a/docs/modules/Optional.ts.md
+++ b/docs/modules/Optional.ts.md
@@ -46,12 +46,14 @@ Added in v2.3.0
   - [modify](#modify)
   - [modifyF](#modifyf)
   - [modifyOption](#modifyoption)
+  - [omit](#omit)
+  - [pick](#pick)
   - [prop](#prop)
-  - [props](#props)
   - [right](#right)
   - [setOption](#setoption)
   - [some](#some)
   - [traverse](#traverse)
+  - [~~props~~](#props)
 - [compositions](#compositions)
   - [compose](#compose)
   - [composeIso](#composeiso)
@@ -257,6 +259,39 @@ export declare const modifyOption: <A>(f: (a: A) => A) => <S>(optional: Optional
 
 Added in v2.3.0
 
+## omit
+
+Return a `Optional` from a `Optional` and a list of props to remove.
+A value-level 'Omit' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const omit: <A, P extends keyof A>(
+  props_0: P,
+  ...props_1: P[]
+) => <S>(sa: Optional<S, A>) => Optional<S, { [K in Exclude<keyof A, P>]: A[K] }>
+```
+
+Added in v2.3.13
+
+## pick
+
+Return a `Optional` from a `Optional` and a list of props.
+A value-level 'Pick' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const pick: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Optional<S, A>) => Optional<S, { [K in P]: A[K] }>
+```
+
+Added in v2.3.13
+
 ## prop
 
 Return a `Optional` from a `Optional` and a prop.
@@ -265,22 +300,6 @@ Return a `Optional` from a `Optional` and a prop.
 
 ```ts
 export declare const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Optional<S, A>) => Optional<S, A[P]>
-```
-
-Added in v2.3.0
-
-## props
-
-Return a `Optional` from a `Optional` and a list of props.
-
-**Signature**
-
-```ts
-export declare const props: <A, P extends keyof A>(
-  props_0: P,
-  props_1: P,
-  ...props_2: P[]
-) => <S>(sa: Optional<S, A>) => Optional<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0
@@ -329,6 +348,22 @@ Return a `Traversal` from a `Optional` focused on a `Traversable`.
 export declare function traverse<T extends URIS>(
   T: Traversable1<T>
 ): <S, A>(sta: Optional<S, Kind<T, A>>) => Traversal<S, A>
+```
+
+Added in v2.3.0
+
+## ~~props~~
+
+Use `fromStruct` instead.
+
+**Signature**
+
+```ts
+export declare const props: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Optional<S, A>) => Optional<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0

--- a/docs/modules/Prism.ts.md
+++ b/docs/modules/Prism.ts.md
@@ -41,12 +41,14 @@ Added in v2.3.0
   - [modify](#modify)
   - [modifyF](#modifyf)
   - [modifyOption](#modifyoption)
+  - [omit](#omit)
+  - [pick](#pick)
   - [prop](#prop)
-  - [props](#props)
   - [right](#right)
   - [set](#set)
   - [some](#some)
   - [traverse](#traverse)
+  - [~~props~~](#props)
 - [compositions](#compositions)
   - [compose](#compose)
   - [composeIso](#composeiso)
@@ -254,6 +256,39 @@ export declare const modifyOption: <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) =
 
 Added in v2.3.0
 
+## omit
+
+Return a `Optional` from a `Prism` and a list of props to remove.
+A value-level 'Omit' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const omit: <A, P extends keyof A>(
+  props_0: P,
+  ...props_1: P[]
+) => <S>(sa: Prism<S, A>) => Optional<S, { [K in Exclude<keyof A, P>]: A[K] }>
+```
+
+Added in v2.3.13
+
+## pick
+
+Return a `Optional` from a `Prism` and a list of props.
+A value-level 'Pick' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const pick: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Prism<S, A>) => Optional<S, { [K in P]: A[K] }>
+```
+
+Added in v2.3.13
+
 ## prop
 
 Return a `Optional` from a `Prism` and a prop.
@@ -262,22 +297,6 @@ Return a `Optional` from a `Prism` and a prop.
 
 ```ts
 export declare const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Prism<S, A>) => Optional<S, A[P]>
-```
-
-Added in v2.3.0
-
-## props
-
-Return a `Optional` from a `Prism` and a list of props.
-
-**Signature**
-
-```ts
-export declare const props: <A, P extends keyof A>(
-  props_0: P,
-  props_1: P,
-  ...props_2: P[]
-) => <S>(sa: Prism<S, A>) => Optional<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0
@@ -326,6 +345,22 @@ Return a `Traversal` from a `Prism` focused on a `Traversable`.
 export declare function traverse<T extends URIS>(
   T: Traversable1<T>
 ): <S, A>(sta: Prism<S, Kind<T, A>>) => Traversal<S, A>
+```
+
+Added in v2.3.0
+
+## ~~props~~
+
+Use `fromStruct` instead.
+
+**Signature**
+
+```ts
+export declare const props: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Prism<S, A>) => Optional<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0

--- a/docs/modules/Traversal.ts.md
+++ b/docs/modules/Traversal.ts.md
@@ -39,12 +39,14 @@ Added in v2.3.0
   - [key](#key)
   - [left](#left)
   - [modify](#modify)
+  - [omit](#omit)
+  - [pick](#pick)
   - [prop](#prop)
-  - [props](#props)
   - [right](#right)
   - [set](#set)
   - [some](#some)
   - [traverse](#traverse)
+  - [~~props~~](#props)
 - [compositions](#compositions)
   - [compose](#compose)
   - [composeIso](#composeiso)
@@ -249,6 +251,39 @@ export declare const modify: <A>(f: (a: A) => A) => <S>(sa: Traversal<S, A>) => 
 
 Added in v2.3.0
 
+## omit
+
+Return a `Traversal` from a `Traversal` and a list of props to remove.
+A value-level 'Omit' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const omit: <A, P extends keyof A>(
+  props_0: P,
+  ...props_1: P[]
+) => <S>(sa: Traversal<S, A>) => Traversal<S, { [K in Exclude<keyof A, P>]: A[K] }>
+```
+
+Added in v2.3.13
+
+## pick
+
+Return a `Traversal` from a `Traversal` and a list of props.
+A value-level 'Pick' (typescript utility type)
+
+**Signature**
+
+```ts
+export declare const pick: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Traversal<S, A>) => Traversal<S, { [K in P]: A[K] }>
+```
+
+Added in v2.3.13
+
 ## prop
 
 Return a `Traversal` from a `Traversal` and a prop.
@@ -257,22 +292,6 @@ Return a `Traversal` from a `Traversal` and a prop.
 
 ```ts
 export declare const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Traversal<S, A>) => Traversal<S, A[P]>
-```
-
-Added in v2.3.0
-
-## props
-
-Return a `Traversal` from a `Traversal` and a list of props.
-
-**Signature**
-
-```ts
-export declare const props: <A, P extends keyof A>(
-  props_0: P,
-  props_1: P,
-  ...props_2: P[]
-) => <S>(sa: Traversal<S, A>) => Traversal<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0
@@ -331,6 +350,22 @@ export declare const traverse: <T extends
   | 'Record'>(
   T: Traversable1<T>
 ) => <S, A>(sta: Traversal<S, Kind<T, A>>) => Traversal<S, A>
+```
+
+Added in v2.3.0
+
+## ~~props~~
+
+Use `fromStruct` instead.
+
+**Signature**
+
+```ts
+export declare const props: <A, P extends keyof A>(
+  props_0: P,
+  props_1: P,
+  ...props_2: P[]
+) => <S>(sa: Traversal<S, A>) => Traversal<S, { [K in P]: A[K] }>
 ```
 
 Added in v2.3.0

--- a/dtslint/ts3.5/Lens.ts
+++ b/dtslint/ts3.5/Lens.ts
@@ -19,11 +19,11 @@ pipe(L.id<A>(), L.prop('d'))
 //
 
 // $ExpectError
-pipe(L.id<A>(), L.props())
+pipe(L.id<A>(), L.pick())
 // $ExpectError
-pipe(L.id<A>(), L.props('a'))
+pipe(L.id<A>(), L.pick('a'))
 
-pipe(L.id<A>(), L.props('a', 'b')) // $ExpectType Lens<A, { a: string; b: number; }>
+pipe(L.id<A>(), L.pick('a', 'b')) // $ExpectType Lens<A, { a: string; b: number; }>
 
 //
 // component

--- a/dtslint/ts3.5/Optional.ts
+++ b/dtslint/ts3.5/Optional.ts
@@ -8,8 +8,8 @@ interface A {
 }
 
 // $ExpectError
-pipe(O.id<A>(), O.props())
+pipe(O.id<A>(), O.pick())
 // $ExpectError
-pipe(O.id<A>(), O.props('a'))
+pipe(O.id<A>(), O.pick('a'))
 
-pipe(O.id<A>(), O.props('a', 'b')) // $ExpectType Optional<A, { a: string; b: number; }>
+pipe(O.id<A>(), O.pick('a', 'b')) // $ExpectType Optional<A, { a: string; b: number; }>

--- a/dtslint/ts3.5/Prism.ts
+++ b/dtslint/ts3.5/Prism.ts
@@ -8,8 +8,8 @@ interface A {
 }
 
 // $ExpectError
-pipe(P.id<A>(), P.props())
+pipe(P.id<A>(), P.pick())
 // $ExpectError
-pipe(P.id<A>(), P.props('a'))
+pipe(P.id<A>(), P.pick('a'))
 
-pipe(P.id<A>(), P.props('a', 'b')) // $ExpectType Optional<A, { a: string; b: number; }>
+pipe(P.id<A>(), P.pick('a', 'b')) // $ExpectType Optional<A, { a: string; b: number; }>

--- a/dtslint/ts3.5/Traversal.ts
+++ b/dtslint/ts3.5/Traversal.ts
@@ -8,8 +8,8 @@ interface A {
 }
 
 // $ExpectError
-pipe(T.id<A>(), T.props())
+pipe(T.id<A>(), T.pick())
 // $ExpectError
-pipe(T.id<A>(), T.props('a'))
+pipe(T.id<A>(), T.pick('a'))
 
-pipe(T.id<A>(), T.props('a', 'b')) // $ExpectType Traversal<A, { a: string; b: number; }>
+pipe(T.id<A>(), T.pick('a', 'b')) // $ExpectType Traversal<A, { a: string; b: number; }>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "monocle-ts",
-  "version": "2.3.10",
+  "version": "2.3.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Iso.ts
+++ b/src/Iso.ts
@@ -218,13 +218,34 @@ export const prop = <A, P extends keyof A>(prop: P): (<S>(sa: Iso<S, A>) => Lens
 
 /**
  * Return a `Lens` from a `Iso` and a list of props.
+ * A value-level 'Pick' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const pick = <A, P extends keyof A>(
+  ...props: readonly [P, P, ...ReadonlyArray<P>]
+): (<S>(sa: Iso<S, A>) => Lens<S, { [K in P]: A[K] }>) => flow(asLens, _.lensPick(...props))
+
+/**
+ * Return a `Lens` from a `Iso` and a list of props to remove.
+ * A value-level 'Omit' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const omit = <A, P extends keyof A>(
+  ...props: readonly [P, ...ReadonlyArray<P>]
+): (<S>(sa: Iso<S, A>) => Lens<S, { [K in Exclude<keyof A, P>]: A[K] }>) => flow(asLens, _.lensOmit(...props))
+
+/**
+ * Use `fromStruct` instead.
  *
  * @category combinators
  * @since 2.3.8
+ * @deprecated
  */
-export const props = <A, P extends keyof A>(
-  ...props: readonly [P, P, ...ReadonlyArray<P>]
-): (<S>(sa: Iso<S, A>) => Lens<S, { [K in P]: A[K] }>) => flow(asLens, _.lensProps(...props))
+export const props = pick
 
 /**
  * Return a `Lens` from a `Iso` focused on a component of a tuple.

--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -202,13 +202,34 @@ export const prop: <A, P extends keyof A>(prop: P) => <S>(sa: Lens<S, A>) => Len
 
 /**
  * Return a `Lens` from a `Lens` and a list of props.
+ * A value-level 'Pick' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const pick: <A, P extends keyof A>(
+  ...props: readonly [P, P, ...ReadonlyArray<P>]
+) => <S>(sa: Lens<S, A>) => Lens<S, { [K in P]: A[K] }> = _.lensPick
+
+/**
+ * Return a `Lens` from a `Lens` and a list of props to remove.
+ * A value-level 'Omit' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const omit: <A, P extends keyof A>(
+  ...props: readonly [P, ...ReadonlyArray<P>]
+) => <S>(sa: Lens<S, A>) => Lens<S, { [K in Exclude<keyof A, P>]: A[K] }> = _.lensOmit
+
+/**
+ * Use `fromStruct` instead.
  *
  * @category combinators
  * @since 2.3.0
+ * @deprecated
  */
-export const props: <A, P extends keyof A>(
-  ...props: readonly [P, P, ...ReadonlyArray<P>]
-) => <S>(sa: Lens<S, A>) => Lens<S, { [K in P]: A[K] }> = _.lensProps
+export const props = pick
 
 /**
  * Return a `Lens` from a `Lens` focused on a component of a tuple.

--- a/src/Optional.ts
+++ b/src/Optional.ts
@@ -224,14 +224,36 @@ export const prop = <A, P extends keyof A>(prop: P): (<S>(sa: Optional<S, A>) =>
 
 /**
  * Return a `Optional` from a `Optional` and a list of props.
+ * A value-level 'Pick' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const pick = <A, P extends keyof A>(
+  ...props: readonly [P, P, ...ReadonlyArray<P>]
+): (<S>(sa: Optional<S, A>) => Optional<S, { [K in P]: A[K] }>) =>
+  compose(pipe(_.lensId<A>(), _.lensPick(...props), _.lensAsOptional))
+
+/**
+ * Return a `Optional` from a `Optional` and a list of props to remove.
+ * A value-level 'Omit' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const omit = <A, P extends keyof A>(
+  ...props: readonly [P, ...ReadonlyArray<P>]
+): (<S>(sa: Optional<S, A>) => Optional<S, { [K in Exclude<keyof A, P>]: A[K] }>) =>
+  compose(pipe(_.lensId<A>(), _.lensOmit(...props), _.lensAsOptional))
+
+/**
+ * Use `fromStruct` instead.
  *
  * @category combinators
  * @since 2.3.0
+ * @deprecated
  */
-export const props = <A, P extends keyof A>(
-  ...props: readonly [P, P, ...ReadonlyArray<P>]
-): (<S>(sa: Optional<S, A>) => Optional<S, { [K in P]: A[K] }>) =>
-  compose(pipe(_.lensId<A>(), _.lensProps(...props), _.lensAsOptional))
+export const props = pick
 
 /**
  * Return a `Optional` from a `Optional` focused on a component of a tuple.

--- a/src/Prism.ts
+++ b/src/Prism.ts
@@ -231,13 +231,35 @@ export const prop = <A, P extends keyof A>(prop: P): (<S>(sa: Prism<S, A>) => Op
 
 /**
  * Return a `Optional` from a `Prism` and a list of props.
+ * A value-level 'Pick' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const pick = <A, P extends keyof A>(
+  ...props: readonly [P, P, ...ReadonlyArray<P>]
+): (<S>(sa: Prism<S, A>) => Optional<S, { [K in P]: A[K] }>) => composeLens(pipe(_.lensId<A>(), _.lensPick(...props)))
+
+/**
+ * Return a `Optional` from a `Prism` and a list of props to remove.
+ * A value-level 'Omit' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const omit = <A, P extends keyof A>(
+  ...props: readonly [P, ...ReadonlyArray<P>]
+): (<S>(sa: Prism<S, A>) => Optional<S, { [K in Exclude<keyof A, P>]: A[K] }>) =>
+  composeLens(pipe(_.lensId<A>(), _.lensOmit(...props)))
+
+/**
+ * Use `fromStruct` instead.
  *
  * @category combinators
  * @since 2.3.0
+ * @deprecated
  */
-export const props = <A, P extends keyof A>(
-  ...props: readonly [P, P, ...ReadonlyArray<P>]
-): (<S>(sa: Prism<S, A>) => Optional<S, { [K in P]: A[K] }>) => composeLens(pipe(_.lensId<A>(), _.lensProps(...props)))
+export const props = pick
 
 /**
  * Return a `Optional` from a `Prism` focused on a component of a tuple.

--- a/src/Traversal.ts
+++ b/src/Traversal.ts
@@ -194,14 +194,36 @@ export const prop = <A, P extends keyof A>(prop: P): (<S>(sa: Traversal<S, A>) =
 
 /**
  * Return a `Traversal` from a `Traversal` and a list of props.
+ * A value-level 'Pick' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const pick = <A, P extends keyof A>(
+  ...props: readonly [P, P, ...ReadonlyArray<P>]
+): (<S>(sa: Traversal<S, A>) => Traversal<S, { [K in P]: A[K] }>) =>
+  compose(pipe(_.lensId<A>(), _.lensPick(...props), _.lensAsTraversal))
+
+/**
+ * Return a `Traversal` from a `Traversal` and a list of props to remove.
+ * A value-level 'Omit' (typescript utility type)
+ *
+ * @category combinators
+ * @since 2.3.13
+ */
+export const omit = <A, P extends keyof A>(
+  ...props: readonly [P, ...ReadonlyArray<P>]
+): (<S>(sa: Traversal<S, A>) => Traversal<S, { [K in Exclude<keyof A, P>]: A[K] }>) =>
+  compose(pipe(_.lensId<A>(), _.lensOmit(...props), _.lensAsTraversal))
+
+/**
+ * Use `fromStruct` instead.
  *
  * @category combinators
  * @since 2.3.0
+ * @deprecated
  */
-export const props = <A, P extends keyof A>(
-  ...props: readonly [P, P, ...ReadonlyArray<P>]
-): (<S>(sa: Traversal<S, A>) => Traversal<S, { [K in P]: A[K] }>) =>
-  compose(pipe(_.lensId<A>(), _.lensProps(...props), _.lensAsTraversal))
+export const props = pick
 
 /**
  * Return a `Traversal` from a `Traversal` focused on a component of a tuple.

--- a/src/index.ts
+++ b/src/index.ts
@@ -374,7 +374,7 @@ export class Lens<S, A> {
    */
   static fromProps<S>(): <P extends keyof S>(props: Array<P>) => Lens<S, { [K in P]: S[K] }>
   static fromProps<S>(): <P extends keyof S>(props: [P, P, ...Array<P>]) => Lens<S, { [K in P]: S[K] }> {
-    return (props) => fromLens(pipe(lens.id<S>(), lens.props(...props)))
+    return (props) => fromLens(pipe(lens.id<S>(), lens.pick(...props)))
   }
 
   /**

--- a/test/Iso.ts
+++ b/test/Iso.ts
@@ -156,16 +156,28 @@ describe('Iso', () => {
     U.deepStrictEqual(lens.set(2)([1]), [2])
   })
 
-  it('props', () => {
+  it('pick', () => {
     type S = readonly [number, string]
     type A = { readonly a: number; readonly b: string }
     const sa: _.Iso<S, A> = _.iso(
       (s) => ({ a: s[0], b: s[1] }),
       (a) => [a.a, a.b]
     )
-    const lens = pipe(sa, _.props('a', 'b'))
+    const lens = pipe(sa, _.pick('a', 'b'))
     U.deepStrictEqual(lens.get([1, 'b']), { a: 1, b: 'b' })
     U.deepStrictEqual(lens.set({ a: 2, b: 'c' })([1, 'b']), [2, 'c'])
+  })
+
+  it('omit', () => {
+    type S = readonly [number, string]
+    type A = { readonly a: number; readonly b: string }
+    const sa: _.Iso<S, A> = _.iso(
+      (s) => ({ a: s[0], b: s[1] }),
+      (a) => [a.a, a.b]
+    )
+    const lens = pipe(sa, _.omit('a'))
+    U.deepStrictEqual(lens.get([1, 'b']), { b: 'b' })
+    U.deepStrictEqual(lens.set({ b: 'c' })([1, 'b']), [1, 'c'])
   })
 
   it('component', () => {

--- a/test/Lens.ts
+++ b/test/Lens.ts
@@ -100,7 +100,7 @@ describe('Lens', () => {
     assert.strictEqual(sa.set(1)(s), s)
   })
 
-  it('props', () => {
+  it('pick', () => {
     interface S {
       readonly a: {
         readonly b: string
@@ -108,7 +108,23 @@ describe('Lens', () => {
         readonly d: boolean
       }
     }
-    const sa = pipe(_.id<S>(), _.prop('a'), _.props('b', 'c'))
+    const sa = pipe(_.id<S>(), _.prop('a'), _.pick('b', 'c'))
+    const s: S = { a: { b: 'b', c: 1, d: true } }
+    U.deepStrictEqual(sa.get(s), { b: 'b', c: 1 })
+    U.deepStrictEqual(sa.set({ b: 'b', c: 2 })(s), { a: { b: 'b', c: 2, d: true } })
+    // should return the same reference
+    assert.strictEqual(sa.set({ b: 'b', c: 1 })(s), s)
+  })
+
+  it('omit', () => {
+    interface S {
+      readonly a: {
+        readonly b: string
+        readonly c: number
+        readonly d: boolean
+      }
+    }
+    const sa = pipe(_.id<S>(), _.prop('a'), _.omit('d'))
     const s: S = { a: { b: 'b', c: 1, d: true } }
     U.deepStrictEqual(sa.get(s), { b: 'b', c: 1 })
     U.deepStrictEqual(sa.set({ b: 'b', c: 2 })(s), { a: { b: 'b', c: 2, d: true } })

--- a/test/Optional.ts
+++ b/test/Optional.ts
@@ -91,8 +91,14 @@ describe('Optional', () => {
     U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1, c: true })), O.some('a'))
   })
 
-  it('props', () => {
-    const sa = pipe(_.id<S>(), _.some, _.props('a', 'b'))
+  it('pick', () => {
+    const sa = pipe(_.id<S>(), _.some, _.pick('a', 'b'))
+    U.deepStrictEqual(sa.getOption(O.none), O.none)
+    U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1, c: true })), O.some({ a: 'a', b: 1 }))
+  })
+
+  it('omit', () => {
+    const sa = pipe(_.id<S>(), _.some, _.omit('c'))
     U.deepStrictEqual(sa.getOption(O.none), O.none)
     U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1, c: true })), O.some({ a: 'a', b: 1 }))
   })

--- a/test/Prism.ts
+++ b/test/Prism.ts
@@ -105,13 +105,24 @@ describe('Prism', () => {
     U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1 })), O.some('a'))
   })
 
-  it('props', () => {
+  it('pick', () => {
     type S = O.Option<{
       readonly a: string
       readonly b: number
       readonly c: boolean
     }>
-    const sa = pipe(_.id<S>(), _.some, _.props('a', 'b'))
+    const sa = pipe(_.id<S>(), _.some, _.pick('a', 'b'))
+    U.deepStrictEqual(sa.getOption(O.none), O.none)
+    U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1, c: true })), O.some({ a: 'a', b: 1 }))
+  })
+
+  it('omit', () => {
+    type S = O.Option<{
+      readonly a: string
+      readonly b: number
+      readonly c: boolean
+    }>
+    const sa = pipe(_.id<S>(), _.some, _.omit('c'))
     U.deepStrictEqual(sa.getOption(O.none), O.none)
     U.deepStrictEqual(sa.getOption(O.some({ a: 'a', b: 1, c: true })), O.some({ a: 'a', b: 1 }))
   })

--- a/test/Traversal.ts
+++ b/test/Traversal.ts
@@ -51,14 +51,37 @@ describe('Traversal', () => {
     )
   })
 
-  it('props', () => {
+  it('pick', () => {
     const sa = pipe(
       _.fromTraversable(A.readonlyArray)<{
         readonly a: string
         readonly b: number
         readonly c: boolean
       }>(),
-      _.props('a', 'b')
+      _.pick('a', 'b')
+    )
+    U.deepStrictEqual(
+      sa.modifyF(Id.identity)((x) => ({ a: x.a, b: x.b * 2 }))([
+        { a: 'a', b: 1, c: true },
+        { a: 'aa', b: 2, c: false },
+        { a: 'aaa', b: 3, c: true }
+      ]),
+      [
+        { a: 'a', b: 2, c: true },
+        { a: 'aa', b: 4, c: false },
+        { a: 'aaa', b: 6, c: true }
+      ]
+    )
+  })
+
+  it('omit', () => {
+    const sa = pipe(
+      _.fromTraversable(A.readonlyArray)<{
+        readonly a: string
+        readonly b: number
+        readonly c: boolean
+      }>(),
+      _.omit('c')
     )
     U.deepStrictEqual(
       sa.modifyF(Id.identity)((x) => ({ a: x.a, b: x.b * 2 }))([


### PR DESCRIPTION
Renames `props` to `pick` and implements `omit`

This naming convention matches the typescript utility types [Pick](https://www.typescriptlang.org/docs/handbook/utility-types.html#picktype-keys) and [Omit](https://www.typescriptlang.org/docs/handbook/utility-types.html#omittype-keys), and similar features in other libraries (e.g. [underscore.js](https://underscorejs.org/docs/modules/pick.html), [lodash](https://lodash.com/docs/4.17.15#pick), etc.)

Partially closes https://github.com/gcanti/fp-ts/issues/1460 ([see comment](https://github.com/gcanti/fp-ts/issues/1460#issuecomment-824204261))
