### PR TITLE
Fix modify type inference

### DIFF
--- a/docs/modules/Iso.ts.md
+++ b/docs/modules/Iso.ts.md
@@ -216,7 +216,7 @@ Added in v2.3.8
 **Signature**
 
 ```ts
-export declare const modify: <A>(f: (a: A) => A) => <S>(sa: Iso<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Iso<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0

--- a/docs/modules/Lens.ts.md
+++ b/docs/modules/Lens.ts.md
@@ -217,7 +217,7 @@ Added in v2.3.0
 **Signature**
 
 ```ts
-export declare const modify: <A, B extends A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0

--- a/docs/modules/Lens.ts.md
+++ b/docs/modules/Lens.ts.md
@@ -217,7 +217,7 @@ Added in v2.3.0
 **Signature**
 
 ```ts
-export declare const modify: <A>(f: (a: A) => A) => <S>(sa: Lens<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0

--- a/docs/modules/Optional.ts.md
+++ b/docs/modules/Optional.ts.md
@@ -221,7 +221,7 @@ Added in v2.3.0
 **Signature**
 
 ```ts
-export declare const modify: <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(optional: Optional<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0
@@ -252,7 +252,9 @@ Added in v2.3.5
 **Signature**
 
 ```ts
-export declare const modifyOption: <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>) => (s: S) => O.Option<S>
+export declare const modifyOption: <A, B extends A = A>(
+  f: (a: A) => B
+) => <S>(optional: Optional<S, A>) => (s: S) => O.Option<S>
 ```
 
 Added in v2.3.0

--- a/docs/modules/Prism.ts.md
+++ b/docs/modules/Prism.ts.md
@@ -218,7 +218,7 @@ Added in v2.3.0
 **Signature**
 
 ```ts
-export declare const modify: <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Prism<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0
@@ -249,7 +249,7 @@ Added in v2.3.5
 **Signature**
 
 ```ts
-export declare const modifyOption: <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => (s: S) => O.Option<S>
+export declare const modifyOption: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Prism<S, A>) => (s: S) => O.Option<S>
 ```
 
 Added in v2.3.0

--- a/docs/modules/Traversal.ts.md
+++ b/docs/modules/Traversal.ts.md
@@ -240,7 +240,7 @@ Added in v2.3.0
 **Signature**
 
 ```ts
-export declare const modify: <A>(f: (a: A) => A) => <S>(sa: Traversal<S, A>) => (s: S) => S
+export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Traversal<S, A>) => (s: S) => S
 ```
 
 Added in v2.3.0

--- a/dtslint/ts3.5/Iso.ts
+++ b/dtslint/ts3.5/Iso.ts
@@ -1,0 +1,25 @@
+import * as _ from '../../src/Iso'
+import { pipe } from 'fp-ts/lib/pipeable'
+
+interface A {
+  a: string
+  b: number
+  c: string | boolean
+}
+
+declare const isoC: _.Iso<A, A['c']>
+
+//
+// modify
+//
+
+// $ExpectType (s: A) => A
+pipe(isoC, _.modify((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => A
+pipe(isoC, _.modify<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => A
+pipe(isoC, _.modify(() => 'foo'))

--- a/dtslint/ts3.5/Lens.ts
+++ b/dtslint/ts3.5/Lens.ts
@@ -7,20 +7,22 @@ interface A {
   c: string | boolean
 }
 
+declare const lensC: L.Lens<A, A['c']>
+
 //
 // modify
 //
 
 // $ExpectType (s: A) => A
-pipe(L.id<A>(), L.prop('c'), L.modify((
+pipe(lensC, L.modify((
   a // $ExpectType string | boolean
 ) => a))
 
 // $ExpectType (s: A) => A
-pipe(L.id<A>(), L.prop('c'), L.modify<string | boolean>(() => 'foo'))
+pipe(lensC, L.modify<string | boolean>(() => 'foo'))
 
 // $ExpectType (s: A) => A
-pipe(L.id<A>(), L.prop('c'), L.modify(() => 'foo'))
+pipe(lensC, L.modify(() => 'foo'))
 
 //
 // prop

--- a/dtslint/ts3.5/Lens.ts
+++ b/dtslint/ts3.5/Lens.ts
@@ -4,8 +4,20 @@ import { pipe } from 'fp-ts/lib/pipeable'
 interface A {
   a: string
   b: number
-  c: boolean
+  c: string | boolean
 }
+
+//
+// modify
+//
+
+// $ExpectType (s: A) => A
+pipe(L.id<A>(), L.prop('c'), L.modify((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => A
+pipe(L.id<A>(), L.prop('c'), L.modify(() => 'foo'))
 
 //
 // prop

--- a/dtslint/ts3.5/Lens.ts
+++ b/dtslint/ts3.5/Lens.ts
@@ -17,6 +17,9 @@ pipe(L.id<A>(), L.prop('c'), L.modify((
 ) => a))
 
 // $ExpectType (s: A) => A
+pipe(L.id<A>(), L.prop('c'), L.modify<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => A
 pipe(L.id<A>(), L.prop('c'), L.modify(() => 'foo'))
 
 //

--- a/dtslint/ts3.5/Optional.ts
+++ b/dtslint/ts3.5/Optional.ts
@@ -4,8 +4,40 @@ import { pipe } from 'fp-ts/lib/pipeable'
 interface A {
   a: string
   b: number
-  c: boolean
+  c: string | boolean
 }
+
+declare const optionalC: O.Optional<A, A['c']>
+
+//
+// modifyOption
+//
+
+// $ExpectType (s: A) => Option<A>
+pipe(optionalC, O.modifyOption((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => Option<A>
+pipe(optionalC, O.modifyOption<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => Option<A>
+pipe(optionalC, O.modifyOption(() => 'foo'))
+
+//
+// modify
+//
+
+// $ExpectType (s: A) => A
+pipe(optionalC, O.modify((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => A
+pipe(optionalC, O.modify<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => A
+pipe(optionalC, O.modify(() => 'foo'))
 
 // $ExpectError
 pipe(O.id<A>(), O.props())

--- a/dtslint/ts3.5/Prism.ts
+++ b/dtslint/ts3.5/Prism.ts
@@ -4,8 +4,44 @@ import { pipe } from 'fp-ts/lib/pipeable'
 interface A {
   a: string
   b: number
-  c: boolean
+  c: string | boolean
 }
+
+declare const prismC: P.Prism<A, A['c']>
+
+//
+// modifyOption
+//
+
+// $ExpectType (s: A) => Option<A>
+pipe(prismC, P.modifyOption((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => Option<A>
+pipe(prismC, P.modifyOption<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => Option<A>
+pipe(prismC, P.modifyOption(() => 'foo'))
+
+//
+// modify
+//
+
+// $ExpectType (s: A) => A
+pipe(prismC, P.modify((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => A
+pipe(prismC, P.modify<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => A
+pipe(prismC, P.modify(() => 'foo'))
+
+//
+// props
+//
 
 // $ExpectError
 pipe(P.id<A>(), P.props())

--- a/dtslint/ts3.5/Traversal.ts
+++ b/dtslint/ts3.5/Traversal.ts
@@ -4,8 +4,25 @@ import { pipe } from 'fp-ts/lib/pipeable'
 interface A {
   a: string
   b: number
-  c: boolean
+  c: string | boolean
 }
+
+declare const traversalC: T.Traversal<A, A['c']>
+
+//
+// modify
+//
+
+// $ExpectType (s: A) => A
+pipe(traversalC, T.modify((
+  a // $ExpectType string | boolean
+) => a))
+
+// $ExpectType (s: A) => A
+pipe(traversalC, T.modify<string | boolean>(() => 'foo'))
+
+// $ExpectType (s: A) => A
+pipe(traversalC, T.modify(() => 'foo'))
 
 // $ExpectError
 pipe(T.id<A>(), T.props())

--- a/src/Iso.ts
+++ b/src/Iso.ts
@@ -168,7 +168,8 @@ export const reverse = <S, A>(sa: Iso<S, A>): Iso<A, S> => iso(sa.reverseGet, sa
  * @category combinators
  * @since 2.3.0
  */
-export const modify = <A>(f: (a: A) => A) => <S>(sa: Iso<S, A>) => (s: S): S => sa.reverseGet(f(sa.get(s)))
+export const modify = <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Iso<S, A>) => (s: S): S =>
+  sa.reverseGet(f(sa.get(s)))
 
 /**
  * @category combinators

--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -149,7 +149,7 @@ export const composeTraversal = <A, B>(ab: Traversal<A, B>): (<S>(sa: Lens<S, A>
  * @category combinators
  * @since 2.3.0
  */
-export const modify = <A>(f: (a: A) => A) => <S>(sa: Lens<S, A>) => (s: S): S => {
+export const modify = <A, B extends A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S): S => {
   const o = sa.get(s)
   const n = f(o)
   return o === n ? s : sa.set(n)(s)

--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -149,7 +149,7 @@ export const composeTraversal = <A, B>(ab: Traversal<A, B>): (<S>(sa: Lens<S, A>
  * @category combinators
  * @since 2.3.0
  */
-export const modify = <A, B extends A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S): S => {
+export const modify = <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Lens<S, A>) => (s: S): S => {
   const o = sa.get(s)
   const n = f(o)
   return o === n ? s : sa.set(n)(s)

--- a/src/Optional.ts
+++ b/src/Optional.ts
@@ -149,8 +149,9 @@ export const composeTraversal = <A, B>(ab: Traversal<A, B>): (<S>(sa: Optional<S
  * @category combinators
  * @since 2.3.0
  */
-export const modifyOption: <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>) => (s: S) => Option<S> =
-  _.optionalModifyOption
+export const modifyOption: <A, B extends A = A>(
+  f: (a: A) => B
+) => <S>(optional: Optional<S, A>) => (s: S) => Option<S> = _.optionalModifyOption
 
 /**
  * @category combinators
@@ -162,7 +163,8 @@ export const setOption = <A>(a: A): (<S>(optional: Optional<S, A>) => (s: S) => 
  * @category combinators
  * @since 2.3.0
  */
-export const modify: <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>) => (s: S) => S = _.optionalModify
+export const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(optional: Optional<S, A>) => (s: S) => S =
+  _.optionalModify
 
 /**
  * @category combinators

--- a/src/Prism.ts
+++ b/src/Prism.ts
@@ -163,13 +163,14 @@ export const set: <A>(a: A) => <S>(sa: Prism<S, A>) => (s: S) => S = _.prismSet
  * @category combinators
  * @since 2.3.0
  */
-export const modifyOption: <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => (s: S) => Option<S> = _.prismModifyOption
+export const modifyOption: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Prism<S, A>) => (s: S) => Option<S> =
+  _.prismModifyOption
 
 /**
  * @category combinators
  * @since 2.3.0
  */
-export const modify: <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => (s: S) => S = _.prismModify
+export const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Prism<S, A>) => (s: S) => S = _.prismModify
 
 /**
  * @category combinators

--- a/src/Traversal.ts
+++ b/src/Traversal.ts
@@ -155,7 +155,7 @@ export const composeOptional: <A, B>(ab: Optional<A, B>) => <S>(sa: Traversal<S,
  * @category combinators
  * @since 2.3.0
  */
-export const modify = <A>(f: (a: A) => A) => <S>(sa: Traversal<S, A>): ((s: S) => S) =>
+export const modify = <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Traversal<S, A>): ((s: S) => S) =>
   sa.modifyF(_.ApplicativeIdentity)(f)
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -169,7 +169,7 @@ export const prismAsTraversal = <S, A>(sa: Prism<S, A>): Traversal<S, A> =>
   )
 
 /** @internal */
-export const prismModifyOption = <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => (s: S): O.Option<S> =>
+export const prismModifyOption = <A, B extends A>(f: (a: A) => B) => <S>(sa: Prism<S, A>) => (s: S): O.Option<S> =>
   pipe(
     sa.getOption(s),
     O.map((o) => {
@@ -179,7 +179,7 @@ export const prismModifyOption = <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>) => 
   )
 
 /** @internal */
-export const prismModify = <A>(f: (a: A) => A) => <S>(sa: Prism<S, A>): ((s: S) => S) => {
+export const prismModify = <A, B extends A>(f: (a: A) => B) => <S>(sa: Prism<S, A>): ((s: S) => S) => {
   const g = prismModifyOption(f)(sa)
   return (s) =>
     pipe(
@@ -238,7 +238,9 @@ export const optionalAsTraversal = <S, A>(sa: Optional<S, A>): Traversal<S, A> =
   )
 
 /** @internal */
-export const optionalModifyOption = <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>) => (s: S): O.Option<S> =>
+export const optionalModifyOption = <A, B extends A>(f: (a: A) => B) => <S>(optional: Optional<S, A>) => (
+  s: S
+): O.Option<S> =>
   pipe(
     optional.getOption(s),
     O.map((a) => {
@@ -248,7 +250,7 @@ export const optionalModifyOption = <A>(f: (a: A) => A) => <S>(optional: Optiona
   )
 
 /** @internal */
-export const optionalModify = <A>(f: (a: A) => A) => <S>(optional: Optional<S, A>): ((s: S) => S) => {
+export const optionalModify = <A, B extends A>(f: (a: A) => B) => <S>(optional: Optional<S, A>): ((s: S) => S) => {
   const g = optionalModifyOption(f)(optional)
   return (s) =>
     pipe(


### PR DESCRIPTION
When using `modify` to set a value (refs #165), I found the inference didn't work when there's a union type.