### PR TITLE
`adjoin` function for `Traversals`

### DIFF
--- a/docs/modules/Lens.ts.md
+++ b/docs/modules/Lens.ts.md
@@ -44,6 +44,7 @@ Added in v2.3.0
   - [left](#left)
   - [modify](#modify)
   - [modifyF](#modifyf)
+  - [product](#product)
   - [prop](#prop)
   - [props](#props)
   - [right](#right)
@@ -242,6 +243,20 @@ export declare function modifyF<F>(
 ```
 
 Added in v2.3.5
+
+## product
+
+Combines two `Lenses` into a `Lens` focusing on a tuple (product) of both `Lenses`.
+This is only a valid `Lens` when both argument `Lenses` focus on disjoint parts
+of the original structure, otherwise the 'you get back what you put in' law is violated.
+
+**Signature**
+
+```ts
+export declare const product: <S, A, B>(lensA: Lens<S, A>, lensB: Lens<S, B>) => Lens<S, readonly [A, B]>
+```
+
+Added in v2.3.14
 
 ## prop
 

--- a/docs/modules/Traversal.ts.md
+++ b/docs/modules/Traversal.ts.md
@@ -39,6 +39,7 @@ Added in v2.3.0
   - [key](#key)
   - [left](#left)
   - [modify](#modify)
+  - [partsOf](#partsof)
   - [prop](#prop)
   - [props](#props)
   - [right](#right)
@@ -244,6 +245,35 @@ export declare const modify: <A, B extends A = A>(f: (a: A) => B) => <S>(sa: Tra
 ```
 
 Added in v2.3.0
+
+## partsOf
+
+Turns a `Traversal` into a `Lens` that focuses on all elements in the traversal
+collected into an array.
+When changing the amount of elements in the array extras will be taken from the
+original array, while any supplied extras will be lost.
+This can violate the 'you get back what you put in law' if you change the number
+of elements in the list.
+
+**Signature**
+
+```ts
+export declare const partsOf: <S, A>(t: Traversal<S, A>) => Lens<S, readonly A[]>
+```
+
+**Example**
+
+```ts
+import * as A from 'fp-ts/Array'
+import { pipe } from 'fp-ts/function'
+import { id, traverse, partsOf } from 'monocle-ts/Traversal'
+
+const s: Array<number> = [1, 2, 3]
+const lens = pipe(id<typeof s>(), traverse(A.Traversable), partsOf)
+assert.deepStrictEqual(lens.get(lens.set([9])(s)), [9, 2, 3])
+```
+
+Added in v2.3.14
 
 ## prop
 

--- a/docs/modules/Traversal.ts.md
+++ b/docs/modules/Traversal.ts.md
@@ -25,6 +25,7 @@ Added in v2.3.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [combinators](#combinators)
+  - [adjoin](#adjoin)
   - [atKey](#atkey)
   - [component](#component)
   - [filter](#filter)
@@ -70,6 +71,19 @@ Added in v2.3.0
 ---
 
 # combinators
+
+## adjoin
+
+Combines two traversals into one.
+This is only a valid traversal when both argument traversals focus on disjoint parts of the original structure.
+
+**Signature**
+
+```ts
+export declare const adjoin: <S, A>(traversalA1: Traversal<S, A>, traversalA2: Traversal<S, A>) => Traversal<S, A>
+```
+
+Added in v2.3.14
 
 ## atKey
 
@@ -353,6 +367,7 @@ export declare const traverse: <T extends
   | 'ReadonlyArray'
   | 'NonEmptyArray'
   | 'Identity'
+  | 'HomogeneousTuple'
   | 'Array'
   | 'Record'>(
   T: Traversable1<T>
@@ -469,6 +484,7 @@ export declare const fromTraversable: {
       | 'ReadonlyArray'
       | 'NonEmptyArray'
       | 'Identity'
+      | 'HomogeneousTuple'
       | 'Array'
       | 'Record'
   >(

--- a/src/Lens.ts
+++ b/src/Lens.ts
@@ -193,6 +193,19 @@ export function filter<A>(predicate: Predicate<A>): <S>(sa: Lens<S, A>) => Optio
 }
 
 /**
+ * Combines two `Lenses` into a `Lens` focusing on a tuple (product) of both `Lenses`.
+ * This is only a valid `Lens` when both argument `Lenses` focus on disjoint parts
+ * of the original structure, otherwise the 'you get back what you put in' law is violated.
+ * @category combinators
+ * @since 2.3.14
+ */
+export const product = <S, A, B>(lensA: Lens<S, A>, lensB: Lens<S, B>): Lens<S, readonly [A, B]> =>
+  lens<S, readonly [A, B]>(
+    (s) => [lensA.get(s), lensB.get(s)] as const,
+    ([a, b]) => flow(lensA.set(a), lensB.set(b))
+  )
+
+/**
  * Return a `Lens` from a `Lens` and a prop.
  *
  * @category combinators

--- a/test/Lens.ts
+++ b/test/Lens.ts
@@ -100,6 +100,30 @@ describe('Lens', () => {
     assert.strictEqual(sa.set(1)(s), s)
   })
 
+  describe('product', () => {
+    interface S {
+      readonly a: string
+      readonly b: number
+    }
+
+    it('joins two disjoint lenses together', () => {
+      const s: S = { a: 'a', b: 1 }
+      const sProduct = _.product(pipe(_.id<S>(), _.prop('a')), pipe(_.id<S>(), _.prop('b')))
+
+      U.deepStrictEqual(sProduct.get(s), ['a', 1])
+      U.deepStrictEqual(sProduct.set(['b', 2])(s), { a: 'b', b: 2 })
+    })
+
+    it('violates the lens laws when the lenses are not focusing disjoint parts of the structure', () => {
+      const s: S = { a: 'unused', b: 1 }
+      const sProduct = _.product(pipe(_.id<S>(), _.prop('b')), pipe(_.id<S>(), _.prop('b')))
+
+      U.deepStrictEqual(sProduct.get(s), [1, 1])
+      // setting [8, 9] doesn't give us back [8, 9], violating the 'you get back what you put in' lens law
+      U.deepStrictEqual(sProduct.get(sProduct.set([8, 9])(s)), [9, 9])
+    })
+  })
+
   it('props', () => {
     interface S {
       readonly a: {

--- a/test/Traversal.ts
+++ b/test/Traversal.ts
@@ -192,4 +192,50 @@ describe('Traversal', () => {
     const sa = pipe(_.id<S>(), _.traverse(RNEA.Traversable), _.fromNullable)
     U.deepStrictEqual(sa.modifyF(Id.identity)((n) => n * 2)([1, undefined, 3]), [2, undefined, 6])
   })
+
+  describe('adjoin', () => {
+    it('joining non-overlapping traversals', () => {
+      const s = {
+        prop1: 1,
+        prop2: 8
+      }
+      const adjoined = _.adjoin(pipe(_.id<typeof s>(), _.prop('prop1')), pipe(_.id<typeof s>(), _.prop('prop2')))
+      const modified = pipe(
+        adjoined,
+        _.modify((a) => a + 1)
+      )(s)
+
+      expect(_.getAll(s)(adjoined)).toEqual([1, 8])
+      expect(modified).toEqual({
+        prop1: 2,
+        prop2: 9
+      })
+    })
+
+    describe('joining overlapping traversals', () => {
+      const s = {
+        prop1: 1,
+        prop2: 8
+      }
+      const adjoinedOverlapping = _.adjoin(
+        pipe(_.id<typeof s>(), _.prop('prop1')),
+        pipe(_.id<typeof s>(), _.prop('prop1'))
+      )
+
+      it('only modifies the overlapping property once', () => {
+        const modified = pipe(
+          adjoinedOverlapping,
+          _.modify((a) => a + 1)
+        )(s)
+
+        expect(modified).toEqual({
+          prop1: 2,
+          prop2: 8
+        })
+      })
+      it('returns the overlapping element multiple times', () => {
+        expect(_.getAll(s)(adjoinedOverlapping)).toEqual([1, 1])
+      })
+    })
+  })
 })

--- a/test/Traversal.ts
+++ b/test/Traversal.ts
@@ -7,6 +7,7 @@ import { monoidSum } from 'fp-ts/lib/Monoid'
 import * as U from './util'
 import { ReadonlyRecord } from 'fp-ts/lib/ReadonlyRecord'
 import * as RNEA from 'fp-ts/lib/ReadonlyNonEmptyArray'
+import * as L from '../src/Lens'
 
 describe('Traversal', () => {
   describe('instances', () => {
@@ -26,6 +27,37 @@ describe('Traversal', () => {
   it('id', () => {
     const ss = _.id<ReadonlyArray<number>>()
     U.deepStrictEqual(ss.modifyF(Id.identity)((ns) => ns.map((n) => n * 2))([1, 2, 3]), [2, 4, 6])
+  })
+
+  describe('partsOf', () => {
+    const s: ReadonlyArray<number> = [1, 8, 11]
+    const partsOfLens = pipe(_.id<typeof s>(), _.traverse(A.Traversable), _.partsOf)
+
+    it('modifies the focused elements', () => {
+      const modified = pipe(partsOfLens, L.modify(A.map((a) => a + 1)))(s)
+
+      U.deepStrictEqual(partsOfLens.get(s), [1, 8, 11])
+      U.deepStrictEqual(partsOfLens.get(modified), [2, 9, 12])
+      U.deepStrictEqual(modified, [2, 9, 12])
+    })
+
+    it('takes remaining elements from the original array when setting to a lower number of elements', () => {
+      const modified = partsOfLens.set([99])(s)
+
+      expect(partsOfLens.get(s)).toEqual([1, 8, 11])
+      // elements 8 and 11 are taken from the original array
+      expect(partsOfLens.get(modified)).toEqual([99, 8, 11])
+      expect(modified).toEqual([99, 8, 11])
+    })
+
+    it('ignores all extra elements when setting to a higher number of elements', () => {
+      const modified = partsOfLens.set([99, 98, 97, 96, 95])(s)
+
+      expect(partsOfLens.get(s)).toEqual([1, 8, 11])
+      // elements 96 and 95 are ignored
+      expect(partsOfLens.get(modified)).toEqual([99, 98, 97])
+      expect(modified).toEqual([99, 98, 97])
+    })
   })
 
   it('prop', () => {

--- a/test/internal.ts
+++ b/test/internal.ts
@@ -1,0 +1,23 @@
+import * as O from 'fp-ts/lib/Option'
+import { TraversableHomogeneousTuple } from '../src/internal'
+import * as U from './util'
+
+describe('internal', () => {
+  describe('TraversableHomogeneousTuple', () => {
+    it('traverse', () => {
+      const traverse = (ta: readonly [number, number]) =>
+        TraversableHomogeneousTuple.traverse(O.Applicative)(
+          ta,
+          (n: number): O.Option<number> => (n % 2 === 0 ? O.none : O.some(n))
+        )
+      U.deepStrictEqual(traverse([1, 2] as const), O.none)
+      U.deepStrictEqual(traverse([1, 3] as const), O.some([1, 3] as const))
+    })
+
+    describe('sequence', () => {
+      const sequence = TraversableHomogeneousTuple.sequence(O.Applicative)
+      U.deepStrictEqual(sequence([O.some(1), O.some(3)]), O.some([1, 3] as const))
+      U.deepStrictEqual(sequence([O.some(1), O.none]), O.none)
+    })
+  })
+})


### PR DESCRIPTION
This adds an `adjoin` function for Traversals, that combines two Traversals into one.
```typescript
const adjoin = <S, A>(traversalA: Traversal<S, A>, traversalB: Traversal<S, A>): Traversal<S, A> => ...
```
I could only do that by more or less translating the version from the [haskell lens library](https://hackage.haskell.org/package/lens-5.2/docs/Control-Lens-Unsound.html#v:adjoin).
For this reason the `partsOf` and `product` functions also come with it.

I was not sure how to best traverse the tuple type returned by `product`. I added a new `Traversable` instance for the `readonly [A, A]` type, though it doesn't look like that's the correct way to build that traverse function. Let me know what a better approach for this is.